### PR TITLE
feat: build and staging deploy to gcs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  # Triggers the workflow when pull request is opened or updated
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # ref: https://github.com/actions/starter-workflows/tree/main/pages
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      # Fix gemfile not found issue
+      - name: Bundle init
+        run: bundle init && bundle add jekyll
+
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default 
+        # run: bundle exec jekyll build
+        run: bundle exec jekyll build --config _config_development.yml
+
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: jekyll-site
+          path: ./_site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to google cloud storage
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      RUN_ID:
+        description: 'Artifact run_id to deploy'
+        required: true
+        default: '<RUN_ID>'
+
+jobs:
+  deploy-to-gcs:
+    runs-on: ubuntu-latest
+    permissions: # Required by google-github-actions/auth
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+    - name: Checkout
+      uses: 'actions/checkout@v4'
+
+    # ref: https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories
+    - name: Download artifacts from build
+      uses: actions/download-artifact@v4
+      with:
+        name: jekyll-site
+        github-token: ${{ secrets.GH_PAT }} # personal access token with actions:read permissions on target repo
+        run-id: ${{ github.event.inputs.RUN_ID }}
+        path: ./site
+
+    - name: Authenticate to Google Cloud
+      uses: 'google-github-actions/auth@v2'
+      with:
+        workload_identity_provider: ${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}
+
+    - name: Upload to GCS
+      uses: 'google-github-actions/upload-cloud-storage@v2'
+      with:
+        path: './site'
+        destination: 'guide-dev'

--- a/_config_development.yml
+++ b/_config_development.yml
@@ -1,0 +1,35 @@
+url: "https://storage.googleapis.com/guide-dev/site"
+sass:
+  sass_dir: assets/css
+  style: :compressed
+timezone: Asia/Taipei
+collections:
+  technology:
+    name: "前端技術原則"
+    output: true
+  visual:
+    name: "視覺設計"
+    output: true
+  components:
+    name: "共用元件"
+    output: true
+i18n:
+  langs: 
+    "en-US": "English (US)"
+    "zh-TW": "正體中文"
+    ja: "日本語"
+    vi: "Tiếng Việt"
+    th: "ไทย"
+  maturity:
+    new:
+      key: 新提案
+      desc: 未完成開發、請勿使用。
+    alpha:
+      key: 封閉測試
+      desc: 開發暫時性完成，可使用。可能仍有親和力或其他使用上問題待透過實測發現。
+    beta:
+      key: 公開測試
+      desc: 開發暫時性完成，歡迎使用。具有完整親和力報告。
+    production:
+      key: 已穩定
+      desc: 開發完成、歡迎使用。應無任何親和力或使用上問題。


### PR DESCRIPTION
## 目的

收到 Pull request 後，可以直接 deploy 到測試環境看

## 使用流程說明

Pull request 會自動觸發 Build action，之後要手動啟動 Deploy action，啟動 Deploy action 需要輸入要部署的 build action workflow `run_id`

## 設定

### Deploy action

`download-artifact@v4` 因為預設有存取相同 workflow 檔案的權限，需要另外給 personal access token 的 read repository 權限，這樣才能下載不同 workflow 的 artifact

### Google cloud storage 設定

#### 新增 bucket

1. [新增](https://cloud.google.com/storage/docs/creating-buckets)一個 bucket（值區）讓 deploy action 上傳
2. [設定公開存取](https://cloud.google.com/storage/docs/access-control/making-data-public)

#### 驗證及授權

1. 參考 google-github-actions/auth，使用 [direct-workload-identity-federation](https://github.com/google-github-actions/auth?tab=readme-ov-file#preferred-direct-workload-identity-federation) 驗證身份（參考步驟1-4），無需使用到 service account
3. 授權 （add-iam-policy-binding）第一步驟產生的 provider 使用 Google Cloud Storage，
member（主體）：principalSet://iam.googleapis.com/<provider>
角色（role）：roles/storage.objectCreator （可建立物件）

## Snapshots

Deploy action 啟動設定
<img width="600" alt="deploy action" src="https://github.com/nics-tw/guide/assets/6376572/cd53de7c-3dc3-49fa-9e0c-6eae642d556a">

取得 Run id 
<img width="600" alt="run id" src="https://github.com/nics-tw/guide/assets/6376572/611b5a4e-52e3-44f9-9817-d78d60a3177d">

## Issue

cache 問題
可以在 cloud storage 上設定 metadata `Cache-Control:no-cache, max-age=0`，或是 client 使用無痕視窗開啟

