### PR TITLE
fix: wrong iframe url, replace site.baseurl with site.url

### DIFF
--- a/_components/landmark/index.md
+++ b/_components/landmark/index.md
@@ -6,7 +6,7 @@ maturity: "alpha"
 
 ### 空白範本
 
-{% capture path %}{{ site.baseurl }}{% link _components/landmark/blank.html %}{% endcapture %}
+{% capture path %}{{ site.url }}{% link _components/landmark/blank.html %}{% endcapture %}
 
 [空白範本]({{ path }})原始碼。
 
@@ -16,7 +16,7 @@ maturity: "alpha"
 
 ### 單欄位範本
 
-{% capture path %}{{ site.baseurl }}{% link _components/landmark/one-column.html %}{% endcapture %}
+{% capture path %}{{ site.url }}{% link _components/landmark/one-column.html %}{% endcapture %}
 
 [單欄位範本]({{ path }})。
 

--- a/_components/skip-to/index.md
+++ b/_components/skip-to/index.md
@@ -13,7 +13,7 @@ maturity: "alpha"
 </skip-to>{% endcapture %}
 <div class="br3 mb4 overflow-hidden">{% include example-html.html content=html %}</div>
 
-{% capture path %}{{ site.baseurl }}{% link _components/skip-to/skip-to.html %}{% endcapture %}
+{% capture path %}{{ site.url }}{% link _components/skip-to/skip-to.html %}{% endcapture %}
 {% include iframe.html src=path %}
 
 #### Custom Element
@@ -35,5 +35,5 @@ maturity: "alpha"
 {% endcapture %}
 <div class="br3 mb4 overflow-hidden">{% include example-html.html content=html %}</div>
 
-{% capture path %}{{ site.baseurl }}{% link _components/skip-to/skip-to-multiple.html %}{% endcapture %}
+{% capture path %}{{ site.url }}{% link _components/skip-to/skip-to-multiple.html %}{% endcapture %}
 {% include iframe.html src=path height=360 %}


### PR DESCRIPTION
The problem is:
If the build option does not provide `baseurl`, the generated URL may be incorrect.

ref: https://mademistakes.com/mastering-jekyll/site-url-baseurl/#what-are-url-and-baseurl

So, fix it by replacing site.baseurl with site.url.