### PR TITLE
Auto deploy to stage every build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,10 @@ jobs:
     with:
           RUN_ID: ${{ github.run_id }}
     secrets: inherit
-  comment:
+  comment: # Required by peter-evans/create-or-update-comment@v4
     runs-on: ubuntu-latest
+    permissions:
+        pull-requests: write
     needs: deploy
     steps:
     - name: Find Comment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
           path: ./_site
   deploy:
     uses: ./.github/workflows/deploy.yml
+    permissions: # Required by google-github-actions/auth
+      contents: 'read'
+      id-token: 'write'
     needs: build
     with:
           RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,9 @@ jobs:
         with:
           name: jekyll-site
           path: ./_site
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    needs: build
+    with:
+          RUN_ID: ${{ github.run_id }}
+    secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,3 +39,23 @@ jobs:
     with:
           RUN_ID: ${{ github.run_id }}
     secrets: inherit
+  comment:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+    - name: Find Comment
+      uses: peter-evans/find-comment@v3
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: Deployed to
+
+    - name: Create or update comment
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          Deployed to https://storage.googleapis.com/guide-dev/${{ github.run_id }}/index.html
+        edit-mode: replace

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,11 @@
 name: Deploy to google cloud storage
 on:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  workflow_call:
     inputs:
       RUN_ID:
         description: 'Artifact run_id to deploy'
         required: true
+        type: string
         default: '<RUN_ID>'
 
 jobs:
@@ -25,8 +25,8 @@ jobs:
       with:
         name: jekyll-site
         github-token: ${{ secrets.GH_PAT }} # personal access token with actions:read permissions on target repo
-        run-id: ${{ github.event.inputs.RUN_ID }}
-        path: ./site
+        run-id: ${{ inputs.RUN_ID }}
+        path: ./${{ inputs.RUN_ID }}
 
     - name: Authenticate to Google Cloud
       uses: 'google-github-actions/auth@v2'
@@ -36,5 +36,5 @@ jobs:
     - name: Upload to GCS
       uses: 'google-github-actions/upload-cloud-storage@v2'
       with:
-        path: './site'
+        path: './${{ inputs.RUN_ID }}'
         destination: 'guide-dev'


### PR DESCRIPTION
#29 deploy build to specific url manually, this update deploy build to different url automatically.

## Auto Deploy 

 [Reuse](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow) deploy workflow: 
 - update `workflow_dispatch` to `workflow_call` 
 - rename build output folder as `github.run_id`, and gcs uses the folder name (`github.run_id`) as part of url, so we can have an unique url every build

## Comment on PR

Create/update comment with deployed url 

## TODO

Make the stage URL expire after a specific period of time