### PR TITLE
Fix/i18n of form

### DIFF
--- a/_components/form/index.md
+++ b/_components/form/index.md
@@ -9,8 +9,8 @@ maturity: "alpha"
 {% capture html %}{% include form/form-elements.html %}{% endcapture %}
 {% include example.html 
   content=html
-  i18n_selector="[for=city],[for=id],[for=name],[for=desc],[for=items]" 
-  i18n="en-US:City of residence,ID type,Full name,Description,Applications"
+  i18n_selector="[for=name],[for=city],[for=desc]" 
+  i18n="en-US:Full name,City of residence,Description"
 %}
 
 #### CSS
@@ -32,8 +32,8 @@ maturity: "alpha"
 {% capture html %}{% include form/form-checkable.html %}{% endcapture %}
 {% include example.html 
   content=html
-  i18n_selector="[for=city],[for=id],[for=name],[for=desc],[for=items]" 
-  i18n="en-US:City of residence,ID type,Full name,Description,Applications"
+  i18n_selector="[for=id],[for=items]" 
+  i18n="en-US:ID type,Lost document replacement"
 %}
 
 #### CSS

--- a/_includes/example.html
+++ b/_includes/example.html
@@ -4,7 +4,7 @@
     {% if include.i18n %}
       {% assign i18n = include.i18n | split: ';' %}
       <select aria-label="語言選擇" data-i18n-selector="{{ include.i18n_selector }}" class="field-select absolute nt2 lh-solid pa1 right-0 mr4 top-0 f7 pointer">
-        <option lang="{{ layout.lang }}" value="default">正體中文</option>
+        <option value="default">正體中文</option>
         {% for lang in i18n %}
           {% assign parts = lang | split: ':' %}
           {% assign name = parts[0] %}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,5 +1,7 @@
 const langMap = new WeakMap()
 
+const langPage= document.documentElement.lang
+
 document.addEventListener('change', (event) => {
   const select = event.target.closest('select')
   if (!select || !select.hasAttribute('data-i18n-selector')) return
@@ -10,7 +12,7 @@ document.addEventListener('change', (event) => {
 
   if (!langMap.get(select)) langMap.set(select, [...elements].map(e => getTextNode(e).data))
 
-  parent.setAttribute('lang', option.lang)
+  if (langPage != option.lang) parent.setAttribute('lang', option.lang)
   let phrases
 
   if (option.value === 'default') {


### PR DESCRIPTION
修正  https://github.com/nics-tw/guide/issues/22

# Root cause
修正前使用 data-phrase 屬性分隔後，指定為 label 文字內容。

## References
https://github.com/nics-tw/guide/blob/e311f88362e539ae6e9e6b82f089e0d1ff86b284/assets/js/main.js#L19

# Workaround
修正前 data-phrase 字串有誤值，暫時調整字串順序與 i18n_selector 順序一致。
```
{% include example.html 
  content=html
  i18n_selector="[for=name],[for=city],[for=desc]" 
  i18n="en-US:Full name,City of residence,Description"
%}
```

# Testing Snapshot
![image](https://github.com/user-attachments/assets/30d4ea14-1352-40a9-a928-c471b1b7528e)

# Note
使用字串順序似乎不好維護、容易誤植。後續應可用 #22 提出的解法調整。