### PR TITLE
fix: forked repo cannot access github action secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,13 @@ on:
   workflow_dispatch:
 
   # Triggers the workflow when pull request is opened or updated
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   build:
+    # Run this job if the pull request is from the same repository or labeled with 'safe-to-deploy'
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event.label.name == 'safe-to-deploy' }}
     runs-on: ubuntu-latest
     steps:
       # ref: https://github.com/actions/starter-workflows/tree/main/pages
@@ -38,19 +41,19 @@ jobs:
           name: jekyll-site
           path: ./_site
   deploy:
+    needs: build
     uses: ./.github/workflows/deploy.yml
     permissions: # Required by google-github-actions/auth
       contents: 'read'
       id-token: 'write'
-    needs: build
     with:
           RUN_ID: ${{ github.run_id }}
     secrets: inherit
   comment: # Required by peter-evans/create-or-update-comment@v4
+    needs: deploy
     runs-on: ubuntu-latest
     permissions:
         pull-requests: write
-    needs: deploy
     steps:
     - name: Find Comment
       uses: peter-evans/find-comment@v3


### PR DESCRIPTION
## Issue

- Secrets are not passed to workflows triggered from forks
  > Error: google-github-actions/auth failed with: the GitHub Action workflow must specify exactly one of "workload_identity_provider" or "credentials_json"! If you are specifying input values via GitHub secrets, ensure the secret is being injected into the environment. By default, secrets are not passed to workflows triggered from forks, including Dependabot.


## Solution
- Replace pull_request event with [pull_request_target](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target)
- And use label to trigger forked repo to build as suggestion in [this article](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)