### PR TITLE
fix: accordion and tab dark theme color

### DIFF
--- a/assets/css/components/accordion.scss
+++ b/assets/css/components/accordion.scss
@@ -1,9 +1,10 @@
 // 變數定義
 $accordion-header-bg: var(--backgroundColor);  
-$accordion-header-active-bg: var(--gov-blue-100);  
+$accordion-header-active-bg: var(--primaryColor);  
 $accordion-body-bg: var(--backgroundColor);  
 $accordion-header-fontColor: var(--textColor); 
-$accordion-body-border: var(--gov-blue-100); 
+$accordion-header-active-fontColor: var(--backgroundColor); 
+$accordion-body-border: var(--borderColor); 
 $accordion-body-active-border:var(--secondaryTextColor);
 $accordion-icon-url: url("/assets/svg/downarrow.svg") ;
 $accordion-icon-active-url: url("/assets/svg/uparrow.svg");
@@ -61,6 +62,7 @@ $accordion-icon-active-url: url("/assets/svg/uparrow.svg");
 
   input[type="checkbox"]:checked + label {
     background: $accordion-header-active-bg;
+    color: $accordion-header-active-fontColor;
 
     &::after {
       background-image: $accordion-icon-active-url;

--- a/assets/css/components/accordion.scss
+++ b/assets/css/components/accordion.scss
@@ -26,7 +26,6 @@ $accordion-icon-active-url: url("/assets/svg/uparrow.svg");
     margin-bottom: 0;
     position: relative;
 
-    opacity: 0.9;
     font-size: 16px;
     font-weight: 600;
     line-height: 1.4;

--- a/assets/css/components/tabs.css
+++ b/assets/css/components/tabs.css
@@ -1,12 +1,12 @@
 :root {
-    --tabs-header-bg: var(--gov-white);
-    --tabs-header-fontColor: var(--gov-gray-500);
-    --tabs-header-active-bg: var(--gov-blue-100);
-    --tabs-header-active-fontColor: var(--gov-black);
-    --tabs-header-hover-bg: var(--gov-blue-50);
-    --tabs-header-hover-fontColor: var(--gov-gray-500);
-    --tabs-body-bg: var(--gov-white);
-    --tabs-border: var(--gov-blue-100);
+    --tabs-header-bg: var(--backgroundColor);
+    --tabs-header-fontColor: var(--textColor);
+    --tabs-header-active-bg: var(--primaryColor);
+    --tabs-header-active-fontColor: var(--backgroundColor);
+    --tabs-header-hover-bg: var(--borderColor);
+    --tabs-header-hover-fontColor: var(--textColor);
+    --tabs-body-bg: var(--backgroundColor);
+    --tabs-border: var(--borderColor);
 }
 
 .tabs {

--- a/assets/svg/uparrow.svg
+++ b/assets/svg/uparrow.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
    <style>
         path {
-            fill: black;
+            fill: white;
         }
         @media (prefers-color-scheme: dark) {
-            path { fill: white; }
+            path { fill: black; }
         }
     </style>
     <path fill-rule='evenodd' d='M1.646 11.354a.5.5 0 0 0 .708 0L8 5.707l5.646 5.647a.5.5 0 0 0 .708-.708l-6-6a.5.5 0 0 0-.708 0l-6 6a.5.5 0 0 0 0 .708z'/>


### PR DESCRIPTION
Fix #49 

## Changes

- 一般項目
  - light theme: 白底黑字
  - dark theme: 黑底白字

- 選取的項目
  - light theme: 黑底白字
  - dark theme: 白底黑字

## Snapshots

### Accordion

<img width="360" alt="截圖 2024-11-07 下午5 43 56" src="https://github.com/user-attachments/assets/f71acecb-18ae-4e99-be26-6ff28330de78">
<img width="360" alt="截圖 2024-11-07 下午5 44 46" src="https://github.com/user-attachments/assets/3b9a8484-a53e-49f5-abfb-4acf9feb155b">

### Tabs

<img width="360" alt="截圖 2024-11-07 下午5 46 22" src="https://github.com/user-attachments/assets/d133b02d-4db8-4d31-b6c6-6a8073d9cc58">
<img width="360" alt="截圖 2024-11-07 下午5 46 57" src="https://github.com/user-attachments/assets/f6f780bc-e67f-4b07-9fcc-dd7cb9faf9b9">



