### PR TITLE
ci: fix runner image deprecated error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     # Run this job if the pull request is from the same repository or labeled with 'safe-to-deploy'
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event.label.name == 'safe-to-deploy' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event.label.name == 'safe-to-deploy' || github.event_name == 'workflow_dispatch'}}
     runs-on: ubuntu-latest
     steps:
       # ref: https://github.com/actions/starter-workflows/tree/main/pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup Ruby
-        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
this should be merged, or github will always uses main branch's `setup-ruby`