### PR TITLE
fix i18n_selector

### DIFF
--- a/_components/button-and-link/index.md
+++ b/_components/button-and-link/index.md
@@ -11,7 +11,7 @@ maturity: "alpha"
   include example.html 
   content=html 
   i18n_selector="button" 
-  i18n="en-US:Submit,Delete,Cancel;ja:送信,削除,キャンセル;vi:Gửi,Xóa,Hủy;th:ส่ง,ลบ,ยกเลิก"
+  i18n="en-US:Submit,Delete,Next;ja:送信,削除,キャンセル;vi:Gửi,Xóa,Hủy;th:ส่ง,ลบ,ยกเลิก"
 %}
 
 #### CSS

--- a/_components/checkable/index.md
+++ b/_components/checkable/index.md
@@ -9,8 +9,8 @@ maturity: "alpha"
 {% capture html %}{% include checkable/radios-with-extra-elements.html %}{% endcapture %}
 {% include example.html 
   content=html
-  i18n_selector="[for=v-healthid-input],[for=v-moica-input],[for=v-phone-input]" 
-  i18n="en-US:Health card ID,Digital Certificate,Cell phone"
+  i18n_selector='[for=v-healthid-input],[for=v-moica-input],[for=v-phone-input],[i18n-method],[i18n-tw-fido],[i18n-description]'
+  i18n="en-US:Health card ID,Digital Certificate,Cell phone,Authentication method,TW FidO authentication,A natural person certificate can be used as an online ID to verify the identities of both parties during data exchange. The 'certificate' includes a 'digital signature' and a 'public key.'"
 %}
 
 #### CSS

--- a/_components/checkable/index.md
+++ b/_components/checkable/index.md
@@ -10,7 +10,7 @@ maturity: "alpha"
 {% include example.html 
   content=html
   i18n_selector='[for=v-healthid-input],[for=v-moica-input],[for=v-phone-input],[i18n-method],[i18n-tw-fido],[i18n-description]'
-  i18n="en-US:Health card ID,Digital Certificate,Cell phone,Authentication method,TW FidO authentication,A natural person certificate can be used as an online ID to verify the identities of both parties during data exchange. The 'certificate' includes a 'digital signature' and a 'public key.'"
+  i18n="en-US:NHI Card,Digital Certificate,Cell phone,Authentication method,TW FidO authentication,A natural person certificate can be used as an online ID to verify the identities of both parties during data exchange. The 'certificate' includes a 'digital signature' and a 'public key.'"
 %}
 
 #### CSS

--- a/_components/form/index.md
+++ b/_components/form/index.md
@@ -9,8 +9,8 @@ maturity: "alpha"
 {% capture html %}{% include form/form-elements.html %}{% endcapture %}
 {% include example.html 
   content=html
-  i18n_selector="[for=name],[for=city],[for=desc]" 
-  i18n="en-US:Full name,City of residence,Description"
+  i18n_selector="[for=name],[for=city],[for=desc],[for=select],[for=taipei],[for=newtaipei],[for=keelung]" 
+  i18n="en-US:Full name,City of residence,Description,Select,Taipei,New Taipei,Keelung"
 %}
 
 #### CSS

--- a/_components/form/index.md
+++ b/_components/form/index.md
@@ -32,8 +32,8 @@ maturity: "alpha"
 {% capture html %}{% include form/form-checkable.html %}{% endcapture %}
 {% include example.html 
   content=html
-  i18n_selector="[for=id],[for=items]" 
-  i18n="en-US:ID type,Lost document replacement"
+  i18n_selector="[for=id],[for=items],[for=v-healthid],[for=v-moica],[for=v-phone],[for=check-h-healthid],[for=check-h-moica],[for=check-h-id]" 
+  i18n="en-US:ID type,Lost document replacement,NHI Card,Digital Certificate,Cell phone,NHI Card,Digital Certificate,ID Card"
 %}
 
 #### CSS

--- a/_includes/checkable/radios-with-extra-elements.html
+++ b/_includes/checkable/radios-with-extra-elements.html
@@ -1,5 +1,5 @@
 <fieldset class="fieldset">
-  <label class="field-label">認證方式</label>
+  <label i18n-method class="field-label">認證方式</label>
   <div class="checkable-wrapper-v">
     <div class="checkable-item">
       <input class="chcecked--extra-fields" type="checkbox" name="identification" id="v-healthid-input" value="healthid">
@@ -15,12 +15,12 @@
     <div class="checkable-item">
       <input class="chcecked--extra-fields" type="checkbox" name="identification" id="v-moica-input" value="moica" checked>
       <label for="v-moica-input">自然人憑證
-        <div class="desc">
+        <div i18n-description class="desc">
           自然人憑證是可以在網路上作資料交換時，如同網路身分證辨識雙方身分。「憑證」包含了「數位簽章」跟「公開金鑰」。
         </div>
       </label>
       <div class="fields">
-        <button type="button" class="button button-primary">行動自然人憑證驗證</button>
+        <button i18n-tw-fido type="button" class="button button-primary">行動自然人憑證驗證</button>
       </div>
       
     </div>

--- a/_includes/form/form-elements.html
+++ b/_includes/form/form-elements.html
@@ -6,10 +6,10 @@
   <fieldset class="fieldset">
     <label for="city" class="field-label">居住城市</label>
     <select class="field-input" id="city">
-      <option>選擇</option>
-      <option>台北市</option>
-      <option>新北市</option>
-      <option>基隆市</option>
+      <option for="select">選擇</option>
+      <option for="taipei">台北市</option>
+      <option for="newtaipei">新北市</option>
+      <option for="keelung">基隆市</option>
     </select>
   </fieldset>
   <fieldset class="fieldset">

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -6,26 +6,80 @@ document.addEventListener('change', (event) => {
   const select = event.target.closest('select')
   if (!select || !select.hasAttribute('data-i18n-selector')) return
   const option = select.selectedOptions[0]
-  const selector = select.getAttribute('data-i18n-selector')
   const parent = option.closest('[data-example]')
-  const elements = parent.querySelectorAll(selector)
 
-  if (!langMap.get(select)) langMap.set(select, [...elements].map(e => getTextNode(e).data))
-
-  if (langPage != option.lang) parent.setAttribute('lang', option.lang)
-  let phrases
-
-  if (option.value === 'default') {
-    phrases = langMap.get(select)
+  const selectors = select.getAttribute('data-i18n-selector').split(',')
+  if (selectors.length > 1) {
+    handleMultipleSelectors(parent, select, option, selectors)
   } else {
-    phrases = option.getAttribute('data-phrases').split(',')
-  }
-  
-  for (let i = 0; i < elements.length; i++) {
-    const textNode = getTextNode(elements[i])
-    textNode.replaceWith(phrases[i] || phrases[0])
+    handleSingleSelector(parent, select, option)
   }
 })
+
+function handleSingleSelector(parent, select, option) {
+  const selector = select.getAttribute('data-i18n-selector')
+  const elements = parent.querySelectorAll(selector)
+
+  // save original i18n data
+  if (!langMap.get(select)) {
+    langMap.set(select, [...elements].map(e => getTextNode(e).data))
+  }
+
+  if (langPage != option.lang) {
+    parent.setAttribute('lang', option.lang)
+  }
+
+  // get which i18n to switch
+  const phrases = option.value === 'default'
+    ? langMap.get(select)
+    : option.getAttribute('data-phrases').split(',')
+
+  // update text, which map phrases in DOM order
+  elements.forEach((element, i) => {
+    const textNode = getTextNode(element)
+    textNode.replaceWith(phrases[i] || phrases[0])
+  })
+}
+
+function handleMultipleSelectors(parent, select, option, selectors) {
+  const selectorMap = new Map()
+  const elements = parent.querySelectorAll(selectors.join(','))
+
+  // create a selectorMap that can get a selector to map to the phrases
+  elements.forEach(element => {
+    const selector = selectors.find(s => element.matches(s))
+    selectorMap.set(selector, {
+      element,
+      textNode: getTextNode(element)
+    })
+  })
+
+  // save original i18n data
+  if (!langMap.get(select)) {
+    const originalTexts = new Map()
+    for (const [selector, { textNode }] of selectorMap) {
+      originalTexts.set(selector, textNode.data)
+    }
+    langMap.set(select, originalTexts)
+  }
+
+  if (langPage != option.lang) {
+    parent.setAttribute('lang', option.lang)
+  }
+
+  // get which i18n to switch
+  const phrases = option.value === 'default'
+    ? langMap.get(select)
+    : new Map(selectors.map((selector, i) => [
+        selector,
+        option.getAttribute('data-phrases').split(',')[i]
+      ]))
+
+  // update text
+  for (const [selector, { textNode }] of selectorMap) {
+    textNode.replaceWith(phrases.get(selector))
+  }
+}
 
 function getTextNode(element) {
   return [...element.childNodes].find(e => e.nodeType === Node.TEXT_NODE)


### PR DESCRIPTION
一對多 (一個 `i18n_selector` 對多個 `i18n` 翻譯)
- 使用一個 i18n_selector query 多個 element，根據 DOM 順序填入`i18n` 翻譯
- 用法參考 [markdown](https://github.com/nics-tw/guide/blob/69c4b0a7fd6b6236540735eadcc643f15ada90c2/_components/button-and-link/index.md?plain=1#L13) [html](https://github.com/nics-tw/guide/blob/69c4b0a7fd6b6236540735eadcc643f15ada90c2/_includes/ctas/button.html#L2)

多對多 (多個 `i18n_selector` 對多個 `i18n` 翻譯)
- markdown 內 i18n_selector 要對應到 html 的 data-attribute
- `i18n` 的內容會一對一對應到 `i18n_selector` 的 element
- 用法[參考](https://github.com/nics-tw/guide/commit/d4a06b821b8ff77816045ea9eff1271ebfb4bdda#diff-28dbd0adcd26f6122984fc5f8a985fe6adc9ada0aa3b14e850f0440232f0f504)