### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/components/official-document-element.js
+++ b/assets/js/components/official-document-element.js
@@ -45,7 +45,7 @@ class OfficialDocumentElement extends HTMLElement {
     od.querySelector('.od-date').textContent = this._insertSpace(date)
     od.querySelector('.od-num').textContent = this._insertSpace(documentMeta)
     const dl = od.querySelector('dl')
-    dl.innerHTML = `${this._dt('主旨', title)}${this._dt('依據', dependency)}${this._dt('公告事項', items)}`
+    dl.innerHTML = `${this._dt('主旨', this._escapeHtml(title))}${this._dt('依據', this._escapeHtml(dependency))}${this._dt('公告事項', this._escapeHtml(items))}`
     od.querySelector('.od-admin').textContent = `${adminTitle}　${adminName}`
 
     return od
@@ -58,6 +58,17 @@ class OfficialDocumentElement extends HTMLElement {
   _dt(title, text) { 
     const splitTitle = title.split('').map(t => `<span>${t}</span>`).join('')
     return `<dt>${splitTitle}</dt><dd>${text}</dd>`
+  }
+
+  _escapeHtml(text) {
+    const map = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#039;'
+    }
+    return text.replace(/[&<>"']/g, function(m) { return map[m] })
   }
 
   _css() {


### PR DESCRIPTION
Potential fix for [https://github.com/nics-tw/guide/security/code-scanning/2](https://github.com/nics-tw/guide/security/code-scanning/2)

To fix the problem, we need to ensure that any text content taken from the DOM and reinserted as HTML is properly escaped to prevent XSS attacks. This can be achieved by using a method to escape HTML special characters before inserting the text back into the DOM.

- We will create a helper function to escape HTML special characters.
- We will use this helper function to escape the text content before it is inserted back into the DOM using `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
