### PR TITLE
遷移 Header、Footer 元件（tmp/0726 → main）

### DIFF
--- a/assets/css/components/footer.scss
+++ b/assets/css/components/footer.scss
@@ -6,12 +6,6 @@
     padding: 20px 0;
 }
 
-.width-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
-}
-
 .footer-content {
     display: flex;
     justify-content: space-between;
@@ -57,21 +51,6 @@
         margin: 5px 0;
     }
 }
-
-// .footer-link {
-//     color: #EBB95F;
-//     text-decoration: none;
-
-//     &:hover {
-//         text-decoration: underline;
-//         color: #F2930E;
-//     }
-
-//     &:focus {
-//         text-decoration: underline;
-//         color: #F2930E;
-//     }
-// }
 
 .footer-inline-list {
     display: flex;
@@ -143,14 +122,8 @@
         text-align: center;
     }
 
-    .footer-info {
-        text-align: center;
-    }
-
-    .footer-legal {
-        text-align: center;
-    }
-
+    .footer-info,
+    .footer-legal,
     .footer-section {
         text-align: center;
     }

--- a/assets/css/components/footer.scss
+++ b/assets/css/components/footer.scss
@@ -22,26 +22,8 @@
     max-height: 60px;
 }
 
-.footer-info {
-    flex: 1;
-    min-width: 250px;
-    margin: 10px 0;
-
-    p {
-        margin: 5px 0;
-    }
-}
-
-.footer-legal {
-    flex: 1;
-    min-width: 250px;
-    margin: 10px 0;
-
-    p {
-        margin: 5px 0;
-    }
-}
-
+.footer-info,
+.footer-legal,
 .footer-section {
     flex: 1;
     min-width: 250px;

--- a/assets/css/components/footer.scss
+++ b/assets/css/components/footer.scss
@@ -1,0 +1,161 @@
+
+/* Footer Styles */
+.footer {
+    background-color: var(--backgroundColorLayer1);
+    // color: #FFFFFF;
+    padding: 20px 0;
+}
+
+.width-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+.footer-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    text-align: left;
+}
+
+.footer-logo {
+    flex: 1;
+}
+
+.footer-logo-img {
+    max-height: 60px;
+}
+
+.footer-info {
+    flex: 1;
+    min-width: 250px;
+    margin: 10px 0;
+
+    p {
+        margin: 5px 0;
+    }
+}
+
+.footer-legal {
+    flex: 1;
+    min-width: 250px;
+    margin: 10px 0;
+
+    p {
+        margin: 5px 0;
+    }
+}
+
+.footer-section {
+    flex: 1;
+    min-width: 250px;
+    margin: 10px 0;
+
+    p {
+        margin: 5px 0;
+    }
+}
+
+// .footer-link {
+//     color: #EBB95F;
+//     text-decoration: none;
+
+//     &:hover {
+//         text-decoration: underline;
+//         color: #F2930E;
+//     }
+
+//     &:focus {
+//         text-decoration: underline;
+//         color: #F2930E;
+//     }
+// }
+
+.footer-inline-list {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin-bottom: 20px;
+}
+
+.footer-inline-list-item {
+    margin: 0 15px;
+}
+
+.footer-support-links {
+    width: 100%;
+    text-align: center;
+}
+
+.footer-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+}
+
+.footer-list-item {
+    margin: 5px 0;
+    flex: 0 0 50%;
+}
+
+.footer-navigation {
+    margin-top: 20px;
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.footer-heading {
+    font-size: 1.2em;
+    margin-bottom: 10px;
+}
+
+.footer-divider {
+    border: 0;
+    border-top: 1px dashed #E5E5E5;
+    margin: 20px 0;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .footer-content {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .footer-navigation {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .footer-info {
+        text-align: center;
+    }
+
+    .footer-legal {
+        text-align: center;
+    }
+
+    .footer-section {
+        text-align: center;
+    }
+
+    .footer-list-item {
+        flex: 0 0 50%;
+    }
+}

--- a/assets/css/components/header.scss
+++ b/assets/css/components/header.scss
@@ -49,19 +49,7 @@
 }
 
 .header-link {
-    // color: #FFFFFF;
-    // text-decoration: none;
     margin: 0 10px;
-
-    // &:hover {
-    //     text-decoration: underline;
-    //     color: #EBB95F;
-    // }
-
-    // &:focus {
-    //     text-decoration: underline;
-    //     color: #EBB95F;
-    // }
 }
 
 .service-name {

--- a/assets/css/components/header.scss
+++ b/assets/css/components/header.scss
@@ -10,20 +10,13 @@
 }
 
 .header-divider {
-    border-top: 1px dashed #000;
+    border-top: 1px dashed var(--borderColor);
     margin: 0;
 }
 
 .header-bottom {
     background-color: var(--backgroundColorLayer1);
     padding: 20px 0;
-}
-
-.width-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
-    width: 100%;
 }
 
 .header-top-container {
@@ -108,7 +101,7 @@
     font-size: 2em;
     background: none;
     border: none;
-    color: white;
+    color: var(--textColor);
     cursor: pointer;
     padding: 10px;
 }

--- a/assets/css/components/header.scss
+++ b/assets/css/components/header.scss
@@ -1,0 +1,212 @@
+/* Header Styles */
+.headerfordemo {
+    background-color: var(--backgroundColorLayer1);
+    // color: #FFFFFF;
+}
+
+.header-top {
+    background-color: var(--backgroundColorLayer1);
+    padding: 10px 0;
+}
+
+.header-divider {
+    border-top: 1px dashed #000;
+    margin: 0;
+}
+
+.header-bottom {
+    background-color: var(--backgroundColorLayer1);
+    padding: 20px 0;
+}
+
+.width-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+    width: 100%;
+}
+
+.header-top-container {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+}
+
+.header-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+}
+
+.header-logo {
+    flex: 0 0 auto;
+}
+
+.header-logotype {
+    max-height: 60px;
+}
+
+.header-content {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    flex: 1;
+    position: relative;
+}
+
+.header-link {
+    // color: #FFFFFF;
+    // text-decoration: none;
+    margin: 0 10px;
+
+    // &:hover {
+    //     text-decoration: underline;
+    //     color: #EBB95F;
+    // }
+
+    // &:focus {
+    //     text-decoration: underline;
+    //     color: #EBB95F;
+    // }
+}
+
+.service-name {
+    font-size: 1.2em;
+    margin: 0 20px;
+    cursor: pointer;
+    position: relative;
+}
+
+.header-navigation {
+    display: none;
+    position: absolute;
+    background-color: var(--backgroundColorLayer1);
+    top: 100%;
+    z-index: 1000;
+}
+
+.header-navigation-list {
+    display: flex;
+    flex-direction: column;
+    list-style: none;
+    padding: 10px;
+    width: 100%;
+}
+
+.header-navigation-item {
+    margin: 5px 0;
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+}
+
+.header-menu-button {
+    display: none;
+    font-size: 2em;
+    background: none;
+    border: none;
+    color: white;
+    cursor: pointer;
+    padding: 10px;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+.small-text {
+    font-size: 0.9em;
+}
+
+.header-additional-links {
+    display: none;
+    padding: 10px 0;
+}
+
+/* Show the dropdown menu when is-visible class is added */
+.js-dropdown-menu.is-visible {
+    display: block;
+    top: calc(100% + 10px);
+    width: 20%;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .header-container {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    .header-top {
+        display: none;
+    }
+
+    .header-content {
+        display: none;
+        flex-direction: column;
+
+        .dropdown {
+            width: 100%;
+
+            .header-navigation {
+                position: static;
+                width: 100%;
+            }
+        }
+
+        a {
+            margin: 10px 0;
+        }
+    }
+
+    .header-content.is-visible {
+        display: flex;
+        background-color: var(--backgroundColorLayer1);
+        padding: 10px;
+        position: absolute;
+        top: 100%;
+        right: 0;
+        min-width: 200px;
+        width: 30%;
+    }
+
+    .header-menu-button {
+        display: block;
+        margin-left: auto;
+        font-size: 2.5em;
+        flex: 0 0 20%;
+        text-align: right;
+    }
+
+    .header-logo {
+        flex: 0 0 40%;
+    }
+
+    .header-additional-links {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .header-actions-row {
+        display: flex;
+        justify-content: center;
+        width: 100%;
+        padding: 5px 0;
+
+        a {
+            margin: 0 10px;
+        }
+    }
+}

--- a/assets/css/components/layout.scss
+++ b/assets/css/components/layout.scss
@@ -1,3 +1,13 @@
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+}
+
+body > :first-child {
+  flex: 1;
+}
+
 .site-header, .site-main, .site-footer {
   max-width:calc(var(--paragraph-width) * 1.5);
   padding: 0 2rem;

--- a/assets/css/guide.scss
+++ b/assets/css/guide.scss
@@ -8,9 +8,7 @@ summary.cursor-help {
   cursor: help;
 }
 
-main {
-  min-height: 90vh;
-}
+
 
 .site-footer {
   background: var(--backgroundColorLayer1);

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,3 +1,5 @@
+@import "components/footer.scss";
+@import "components/header.scss";
 @import "variables"; //背景黑底設定
 @import "reset";
 @import "tachyons";

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,10 +1,10 @@
-@import "components/footer.scss";
-@import "components/header.scss";
 @import "variables"; //背景黑底設定
 @import "reset";
 @import "tachyons";
 @import "color";
 @import "typography";
+@import "components/footer.scss";
+@import "components/header.scss";
 @import "components/ctas";
 @import "components/skip-to"; //首頁 "跳至內容區字樣" 消失
 @import "components/warning-text";

--- a/content/components/footer/_index.md
+++ b/content/components/footer/_index.md
@@ -1,0 +1,18 @@
+---
+title: 頁尾 (Footer)
+maturity: "new"
+---
+
+### 基本頁尾
+
+- 頁尾提供網站的附加資訊，如版權聲明、聯繫方式或是網站的其他資訊。
+
+{{< live-example partial="footer/footer.html" >}}
+
+### 頁尾與連結
+
+{{< live-example partial="footer/footer_link.html" >}}
+
+### 頁尾與導覽
+
+{{< live-example partial="footer/footer_service.html" >}}

--- a/content/components/header/_index.md
+++ b/content/components/header/_index.md
@@ -1,0 +1,20 @@
+---
+title: 頁首 (Header)
+maturity: "new"
+---
+
+### 基本頁首
+
+- 頁首包含網站 logo、導覽列，幫助使用者快速了解網站內容和瀏覽不同頁面。
+
+{{< live-example partial="header/header.html" >}}
+
+### 頁首與導覽列
+
+{{< live-example partial="header/header_link.html" >}}
+
+### JavaScript
+
+下載 [header.js]({{< relURL "js/components/header.js" >}}) 檔案。
+
+{{< asset-script "js/components/header.js" >}}

--- a/layouts/_partials/footer/footer.html
+++ b/layouts/_partials/footer/footer.html
@@ -1,0 +1,15 @@
+
+<footer class="footer">
+    <div class="width-container">
+        <div class="footer-content">
+            <div class="footer-logo">
+                <img src="{{ "favicon.png" | absURL }}" alt="機構標誌" class="footer-logo-img">
+            </div>
+            <div class="footer-info">
+                <p>服務電話: <a href="tel:+886-2-2739-1000" class="footer-link">02-2739-1000</a></p>
+                <p>傳真電話: 02-2733-1655</p>
+                <p>地址: 100057 臺北市中正區延平南路143號4樓</p>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/layouts/_partials/footer/footer_link.html
+++ b/layouts/_partials/footer/footer_link.html
@@ -24,7 +24,7 @@
                 <p>更新日期: 2024/03/13</p>
                 <p><a href="#" class="footer-link">隱私權及網站安全政策</a> / <a href="#" class="footer-link">政府網站資料開放宣告</a>
                 </p>
-                <p>版權所有 © 2024 國家資通安全研究院</p>
+                <p>版權所有 © {{ now.Format "2006" }} 國家資通安全研究院</p>
             </div>
         </div>
     </div>

--- a/layouts/_partials/footer/footer_link.html
+++ b/layouts/_partials/footer/footer_link.html
@@ -1,0 +1,31 @@
+
+<footer class="footer">
+    <div class="width-container">
+        <div class="footer-support-links">
+            <h2 class="visually-hidden">支援連結</h2>
+            <ul class="footer-inline-list">
+                <li class="footer-inline-list-item"><a class="footer-link" href="#">幫助</a></li>
+                <li class="footer-inline-list-item"><a class="footer-link" href="#">Cookies</a></li>
+                <li class="footer-inline-list-item"><a class="footer-link" href="#">聯絡</a></li>
+                <li class="footer-inline-list-item"><a class="footer-link" href="#">條款和條件</a></li>
+            </ul>
+        </div>
+        <hr class="footer-divider">
+        <div class="footer-content">
+            <div class="footer-logo">
+                <img src="{{ "favicon.png" | absURL }}" alt="機構標誌" class="footer-logo-img">
+            </div>
+            <div class="footer-info">
+                <p>服務電話: <a href="tel:+886-2-2739-1000" class="footer-link">02-2739-1000</a></p>
+                <p>傳真電話: 02-2733-1655</p>
+                <p>地址: 100057 臺北市中正區延平南路143號4樓</p>
+            </div>
+            <div class="footer-legal">
+                <p>更新日期: 2024/03/13</p>
+                <p><a href="#" class="footer-link">隱私權及網站安全政策</a> / <a href="#" class="footer-link">政府網站資料開放宣告</a>
+                </p>
+                <p>版權所有 © 2024 國家資通安全研究院</p>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/layouts/_partials/footer/footer_service.html
+++ b/layouts/_partials/footer/footer_service.html
@@ -1,0 +1,46 @@
+
+<footer class="footer">
+    <div class="width-container">
+        <div class="footer-navigation">
+            <div class="footer-section">
+                <h2 class="footer-heading">服務和訊息</h2>
+                <ul class="footer-list">
+                    <li class="footer-list-item"><a class="footer-link" href="#">服務1</a></li>
+                    <li class="footer-list-item"><a class="footer-link" href="#">服務2</a></li>
+                    <li class="footer-list-item"><a class="footer-link" href="#">服務3</a></li>
+                    <li class="footer-list-item"><a class="footer-link" href="#">服務4</a></li>
+                    <li class="footer-list-item"><a class="footer-link" href="#">服務5</a></li>
+                    <li class="footer-list-item"><a class="footer-link" href="#">服務6</a></li>
+                </ul>
+            </div>
+            <div class="footer-section">
+                <h2 class="footer-heading">部門和政策</h2>
+                <ul class="footer-list">
+                    <li class="footer-list-item"><a class="footer-link" href="#">連結1</a></li>
+                    <li class="footer-list-item"><a class="footer-link" href="#">連結2</a></li>
+                    <li class="footer-list-item"><a class="footer-link" href="#">連結3</a></li>
+                    <li class="footer-list-item"><a class="footer-link" href="#">連結4</a></li>
+                    <li class="footer-list-item"><a class="footer-link" href="#">連結5</a></li>
+                    <li class="footer-list-item"><a class="footer-link" href="#">連結6</a></li>
+                </ul>
+            </div>
+        </div>
+        <hr class="footer-divider">
+        <div class="footer-content">
+            <div class="footer-logo">
+                <img src="{{ "favicon.png" | absURL }}" alt="機構標誌" class="footer-logo-img">
+            </div>
+            <div class="footer-info">
+                <p>服務電話: <a href="tel:+886-2-2739-1000" class="footer-link">02-2739-1000</a></p>
+                <p>傳真電話: 02-2733-1655</p>
+                <p>地址: 100057 臺北市中正區延平南路143號4樓</p>
+            </div>
+            <div class="footer-legal">
+                <p>更新日期: 2024/03/13</p>
+                <p><a href="#" class="footer-link">隱私權及網站安全政策</a> / <a href="#" class="footer-link">政府網站資料開放宣告</a>
+                </p>
+                <p>版權所有 © 2024 國家資通安全研究院</p>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/layouts/_partials/footer/footer_service.html
+++ b/layouts/_partials/footer/footer_service.html
@@ -39,7 +39,7 @@
                 <p>更新日期: 2024/03/13</p>
                 <p><a href="#" class="footer-link">隱私權及網站安全政策</a> / <a href="#" class="footer-link">政府網站資料開放宣告</a>
                 </p>
-                <p>版權所有 © 2024 國家資通安全研究院</p>
+                <p>版權所有 © {{ now.Format "2006" }} 國家資通安全研究院</p>
             </div>
         </div>
     </div>

--- a/layouts/_partials/header/header.html
+++ b/layouts/_partials/header/header.html
@@ -1,0 +1,21 @@
+<header class="headerfordemo" data-module="header">
+    <div class="header-top">
+        <div class="width-container header-top-container">
+            <div class="header-actions">
+                <a href="#" class="header-link small-text">網站導覽</a>
+                <a href="#" class="header-link small-text" lang="zh-TW">中文</a>
+                <a href="#" class="header-link small-text" lang="en">英文</a>
+            </div>
+        </div>
+    </div>
+    <div class="header-divider width-container"></div>
+    <div class="header-bottom">
+        <div class="width-container">
+            <div class="header-logo">
+                <a href="#" class="header-link">
+                    <img src="{{ "favicon.png" | absURL }}" alt="網站標誌" class="header-logotype">
+                </a>
+            </div>
+        </div>
+    </div>
+</header>

--- a/layouts/_partials/header/header_link.html
+++ b/layouts/_partials/header/header_link.html
@@ -1,0 +1,37 @@
+<header class="headerfordemo" data-module="header">
+    <div class="header-top">
+        <div class="width-container header-top-container">
+            <div class="header-actions">
+                <a href="#" class="header-link small-text">網站導覽</a>
+                <a href="#" class="header-link small-text" lang="zh-TW">中文</a>
+                <a href="#" class="header-link small-text" lang="en">英文</a>
+            </div>
+        </div>
+    </div>
+    <div class="header-divider width-container"></div>
+    <div class="header-bottom">
+        <div class="width-container header-container">
+            <div class="header-logo">
+                <a href="#" class="header-link">
+                    <img src="{{ "favicon.png" | absURL }}" alt="網站標誌" class="header-logotype">
+                </a>
+            </div>
+            <button class="header-menu-button" aria-controls="navigation" aria-expanded="false"
+                aria-label="Toggle navigation">≡</button>
+            <div class="header-content">
+                    <a href="#" class="header-link service-name">Service name 1 </a>
+                    <a href="#" class="header-link service-name">Service name 2 </a>
+                    <a href="#" class="header-link service-name">Service name 3 </a>
+                <!-- Additional links for mobile view -->
+                <div class="header-additional-links">
+                    <div class="header-divider width-container"></div>
+                    <div class="header-actions-row">
+                        <a href="#" class="header-link small-text">網站導覽</a>
+                        <a href="#" class="header-link small-text">中文</a>
+                        <a href="#" class="header-link small-text">英文</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>

--- a/layouts/_partials/header/header_link.html
+++ b/layouts/_partials/header/header_link.html
@@ -17,7 +17,7 @@
                 </a>
             </div>
             <button class="header-menu-button" aria-controls="navigation" aria-expanded="false"
-                aria-label="Toggle navigation">≡</button>
+                aria-label="Toggle navigation"><span aria-hidden="true">≡</span></button>
             <div class="header-content">
                     <a href="#" class="header-link service-name">Service name 1 </a>
                     <a href="#" class="header-link service-name">Service name 2 </a>

--- a/layouts/_partials/header/header_linklevel.html
+++ b/layouts/_partials/header/header_linklevel.html
@@ -1,0 +1,82 @@
+<header class="headerfordemo" data-module="header">
+    <div class="header-top">
+        <div class="width-container header-top-container">
+            <div class="header-actions">
+                <a href="#" class="header-link small-text">網站導覽</a>
+                <a href="#" class="header-link small-text" lang="zh-TW">中文</a>
+                <a href="#" class="header-link small-text" lang="en">英文</a>
+            </div>
+        </div>
+    </div>
+    <div class="header-divider width-container"></div>
+    <div class="header-bottom">
+        <div class="width-container header-container">
+            <div class="header-logo">
+                <a href="#" class="header-link">
+                    <img src="{{ "favicon.png" | absURL }}" alt="網站標誌" class="header-logotype">
+                </a>
+            </div>
+            <button class="header-menu-button" aria-controls="navigation" aria-expanded="false"
+                aria-label="Toggle navigation">≡</button>
+            <div class="header-content">
+                <div class="dropdown">
+                    <a href="#" class="header-link service-name js-dropdown-toggle">Service name 1 <span
+                            class="arrow-down">▼</span></a>
+                    <nav aria-label="Hierarchical Menu" class="header-navigation js-dropdown-menu">
+                        <ul class="header-navigation-list">
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    1</a></li>
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    2</a></li>
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    3</a></li>
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    4</a></li>
+                        </ul>
+                    </nav>
+                </div>
+                <div class="dropdown">
+                    <a href="#" class="header-link service-name js-dropdown-toggle">Service name 2 <span
+                            class="arrow-down">▼</span></a>
+                    <nav aria-label="Hierarchical Menu" class="header-navigation js-dropdown-menu">
+                        <ul class="header-navigation-list">
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    1</a></li>
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    2</a></li>
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    3</a></li>
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    4</a></li>
+                        </ul>
+                    </nav>
+                </div>
+                <div class="dropdown">
+                    <a href="#" class="header-link service-name js-dropdown-toggle">Service name 3 <span
+                            class="arrow-down">▼</span></a>
+                    <nav aria-label="Hierarchical Menu" class="header-navigation js-dropdown-menu">
+                        <ul class="header-navigation-list">
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    1</a></li>
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    2</a></li>
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    3</a></li>
+                            <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
+                                    4</a></li>
+                        </ul>
+                    </nav>
+                </div>
+                <!-- Additional links for mobile view -->
+                <div class="header-additional-links">
+                    <div class="header-divider width-container"></div>
+                    <div class="header-actions-row">
+                        <a href="#" class="header-link small-text">網站導覽</a>
+                        <a href="#" class="header-link small-text" lang="zh-TW">中文</a>
+                        <a href="#" class="header-link small-text" lang="en">英文</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>

--- a/layouts/_partials/header/header_linklevel.html
+++ b/layouts/_partials/header/header_linklevel.html
@@ -17,11 +17,11 @@
                 </a>
             </div>
             <button class="header-menu-button" aria-controls="navigation" aria-expanded="false"
-                aria-label="Toggle navigation">≡</button>
+                aria-label="Toggle navigation"><span aria-hidden="true">≡</span></button>
             <div class="header-content">
                 <div class="dropdown">
-                    <a href="#" class="header-link service-name js-dropdown-toggle">Service name 1 <span
-                            class="arrow-down">▼</span></a>
+                    <a href="#" class="header-link service-name js-dropdown-toggle" aria-haspopup="true" aria-expanded="false">Service name 1 <span
+                            class="arrow-down" aria-hidden="true">▼</span></a>
                     <nav aria-label="Hierarchical Menu" class="header-navigation js-dropdown-menu">
                         <ul class="header-navigation-list">
                             <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
@@ -36,8 +36,8 @@
                     </nav>
                 </div>
                 <div class="dropdown">
-                    <a href="#" class="header-link service-name js-dropdown-toggle">Service name 2 <span
-                            class="arrow-down">▼</span></a>
+                    <a href="#" class="header-link service-name js-dropdown-toggle" aria-haspopup="true" aria-expanded="false">Service name 2 <span
+                            class="arrow-down" aria-hidden="true">▼</span></a>
                     <nav aria-label="Hierarchical Menu" class="header-navigation js-dropdown-menu">
                         <ul class="header-navigation-list">
                             <li class="header-navigation-item"><a class="header-link" href="#">Navigation item
@@ -52,8 +52,8 @@
                     </nav>
                 </div>
                 <div class="dropdown">
-                    <a href="#" class="header-link service-name js-dropdown-toggle">Service name 3 <span
-                            class="arrow-down">▼</span></a>
+                    <a href="#" class="header-link service-name js-dropdown-toggle" aria-haspopup="true" aria-expanded="false">Service name 3 <span
+                            class="arrow-down" aria-hidden="true">▼</span></a>
                     <nav aria-label="Hierarchical Menu" class="header-navigation js-dropdown-menu">
                         <ul class="header-navigation-list">
                             <li class="header-navigation-item"><a class="header-link" href="#">Navigation item

--- a/layouts/_shortcodes/live-example.html
+++ b/layouts/_shortcodes/live-example.html
@@ -6,4 +6,5 @@
 {{ $inject_data := "" }}
 {{ if eq $customElement "true" }}{{ $inject_data = $raw_content | base64Encode }}{{ end }}
 {{ $rendered_content := cond (eq $customElement "true") "" (partial $partial_name .) }}
-{{ partial "example.html" (dict "rendered_content" $rendered_content "raw_content" $raw_content "inject_html_data" $inject_data "context" .) }}
+{{ $code_content := cond (eq $customElement "true") $raw_content $rendered_content }}
+{{ partial "example.html" (dict "rendered_content" $rendered_content "raw_content" $code_content "inject_html_data" $inject_data "context" .) }}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -33,26 +33,28 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body class="{{ if .IsHome }}one-col{{ end }}">
-  <skip-to><a href="#main" class="skip-to">跳至主要內容區</a></skip-to>
-  {{ block "header" . }}
-  <header class="header ph4 pv4">
-    <a href="{{ site.Home.RelPermalink }}" class="logo no-underline bw1 color-inherit inline-flex items-center">
-      <div class="logo-svg mr3">{{ partial "components.svg" . }}</div>
-      <h1 class="heading4">政府網站設計原則</h1>
-    </a>
-  </header>
-  {{ end }}
-  <main {{ if .IsHome }}id="main"{{ end }} class="{{ if .IsHome }}site-main{{ else }}flex flex-wrap flex-nowrap-l content-start pa4 bt{{ end }}">
-    {{ block "sidebar" . }}
-    <nav aria-label="主要" class="w-100 mw5 w5-m mt2 flex-shrink-0 overflow-auto h-auto-l h4 mb4">
-      {{ partial "nav.html" . }}
-    </nav>
+<body>
+  <div class="{{ if .IsHome }}one-col{{ end }}">
+    <skip-to><a href="#main" class="skip-to">跳至主要內容區</a></skip-to>
+    {{ block "header" . }}
+    <header class="header ph4 pv4">
+      <a href="{{ site.Home.RelPermalink }}" class="logo no-underline bw1 color-inherit inline-flex items-center">
+        <div class="logo-svg mr3">{{ partial "components.svg" . }}</div>
+        <h1 class="heading4">政府網站設計原則</h1>
+      </a>
+    </header>
     {{ end }}
-    <div {{ if not .IsHome }}id="main"{{ end }} class="{{ if not .IsHome }}ml4-l flex-auto{{ end }}">
-      {{ block "main" . }}{{ end }}
-    </div>
-  </main>
+    <main {{ if .IsHome }}id="main"{{ end }} class="{{ if .IsHome }}site-main{{ else }}flex flex-wrap flex-nowrap-l content-start pa4 bt{{ end }}">
+      {{ block "sidebar" . }}
+      <nav aria-label="主要" class="w-100 mw5 w5-m mt2 flex-shrink-0 overflow-auto h-auto-l h4 mb4">
+        {{ partial "nav.html" . }}
+      </nav>
+      {{ end }}
+      <div {{ if not .IsHome }}id="main"{{ end }} class="{{ if not .IsHome }}ml4-l flex-auto{{ end }}">
+        {{ block "main" . }}{{ end }}
+      </div>
+    </main>
+  </div>
   <div class="one-column bg-layer1">
     <footer class="site-footer f6 flex items-start gap4">
       <div class="lh-solid w2">{{ partial "components.svg" . }}</div>

--- a/static/js/components/header.js
+++ b/static/js/components/header.js
@@ -1,14 +1,14 @@
 document.addEventListener('DOMContentLoaded', function () {
-    var headers = document.querySelectorAll('.headerfordemo');
+    const headers = document.querySelectorAll('.headerfordemo');
 
     headers.forEach(function (header) {
-        var decreaseFontButtons = header.querySelectorAll('#decreaseFont, #mobileDecreaseFont');
-        var defaultFontButtons = header.querySelectorAll('#defaultFont, #mobileDefaultFont');
-        var increaseFontButtons = header.querySelectorAll('#increaseFont, #mobileIncreaseFont');
-        var body = document.body;
-        var currentFontSize = 16;
-        var minFontSize = 12;
-        var maxFontSize = 24;
+        const decreaseFontButtons = header.querySelectorAll('#decreaseFont, #mobileDecreaseFont');
+        const defaultFontButtons = header.querySelectorAll('#defaultFont, #mobileDefaultFont');
+        const increaseFontButtons = header.querySelectorAll('#increaseFont, #mobileIncreaseFont');
+        const body = document.body;
+        let currentFontSize = 16;
+        const minFontSize = 12;
+        const maxFontSize = 24;
 
         function updateFontSize(size) {
             body.style.fontSize = size + 'px';
@@ -44,14 +44,14 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         });
 
-        var dropdownToggles = header.querySelectorAll('.js-dropdown-toggle');
-        var dropdownMenus = header.querySelectorAll('.js-dropdown-menu');
+        const dropdownToggles = header.querySelectorAll('.js-dropdown-toggle');
+        const dropdownMenus = header.querySelectorAll('.js-dropdown-menu');
 
         dropdownToggles.forEach(function (toggle, index) {
             toggle.addEventListener('click', function (event) {
                 event.preventDefault();
-                var menu = dropdownMenus[index];
-                var isVisible = menu.classList.contains('is-visible');
+                const menu = dropdownMenus[index];
+                const isVisible = menu.classList.contains('is-visible');
                 dropdownMenus.forEach(function (menu) {
                     menu.classList.remove('is-visible');
                 });
@@ -63,12 +63,12 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         });
 
-        var menuButton = header.querySelector('.header-menu-button');
-        var headerContent = header.querySelector('.header-content');
+        const menuButton = header.querySelector('.header-menu-button');
+        const headerContent = header.querySelector('.header-content');
 
         if (menuButton && headerContent) {
             menuButton.addEventListener('click', function () {
-                var isExpanded = menuButton.getAttribute('aria-expanded') === 'true';
+                const isExpanded = menuButton.getAttribute('aria-expanded') === 'true';
                 menuButton.setAttribute('aria-expanded', !isExpanded);
                 headerContent.classList.toggle('is-visible');
             });

--- a/static/js/components/header.js
+++ b/static/js/components/header.js
@@ -1,0 +1,77 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var headers = document.querySelectorAll('.headerfordemo');
+
+    headers.forEach(function (header) {
+        var decreaseFontButtons = header.querySelectorAll('#decreaseFont, #mobileDecreaseFont');
+        var defaultFontButtons = header.querySelectorAll('#defaultFont, #mobileDefaultFont');
+        var increaseFontButtons = header.querySelectorAll('#increaseFont, #mobileIncreaseFont');
+        var body = document.body;
+        var currentFontSize = 16;
+        var minFontSize = 12;
+        var maxFontSize = 24;
+
+        function updateFontSize(size) {
+            body.style.fontSize = size + 'px';
+            body.setAttribute('aria-live', 'polite');
+            body.setAttribute('aria-label', 'Current font size: ' + size + ' pixels');
+        }
+
+        decreaseFontButtons.forEach(function (button) {
+            button.addEventListener('click', function (event) {
+                event.preventDefault();
+                if (currentFontSize > minFontSize) {
+                    currentFontSize -= 1;
+                    updateFontSize(currentFontSize);
+                }
+            });
+        });
+
+        defaultFontButtons.forEach(function (button) {
+            button.addEventListener('click', function (event) {
+                event.preventDefault();
+                currentFontSize = 16;
+                updateFontSize(currentFontSize);
+            });
+        });
+
+        increaseFontButtons.forEach(function (button) {
+            button.addEventListener('click', function (event) {
+                event.preventDefault();
+                if (currentFontSize < maxFontSize) {
+                    currentFontSize += 1;
+                    updateFontSize(currentFontSize);
+                }
+            });
+        });
+
+        var dropdownToggles = header.querySelectorAll('.js-dropdown-toggle');
+        var dropdownMenus = header.querySelectorAll('.js-dropdown-menu');
+
+        dropdownToggles.forEach(function (toggle, index) {
+            toggle.addEventListener('click', function (event) {
+                event.preventDefault();
+                var menu = dropdownMenus[index];
+                var isVisible = menu.classList.contains('is-visible');
+                dropdownMenus.forEach(function (menu) {
+                    menu.classList.remove('is-visible');
+                });
+                if (!isVisible) {
+                    menu.classList.add('is-visible');
+                } else {
+                    menu.classList.remove('is-visible');
+                }
+            });
+        });
+
+        var menuButton = header.querySelector('.header-menu-button');
+        var headerContent = header.querySelector('.header-content');
+
+        if (menuButton && headerContent) {
+            menuButton.addEventListener('click', function () {
+                var isExpanded = menuButton.getAttribute('aria-expanded') === 'true';
+                menuButton.setAttribute('aria-expanded', !isExpanded);
+                headerContent.classList.toggle('is-visible');
+            });
+        }
+    });
+});


### PR DESCRIPTION
## 目的
將 tmp/0726 上的 Header（頁首）、Footer（頁尾） 元件以 Hugo 格式遷移到 main，並調整 live-example 的顯示方式。

## 變更摘要

Commit 1 — feat: 新增 Header、Footer 元件（含 SCSS、JS、layout 與 Jekyll→Hugo 語法修正）
新增 Header 三種版型（header.html、header_link.html、header_linklevel.html）與說明頁
新增 Footer 三種版型（footer.html、footer_link.html、footer_service.html）與說明頁
新增/調整 SCSS、JS、layout，並完成 Jekyll→Hugo 語法轉換（如 absURL、favicon 路徑、footer 服務電話 tel: 連結）
