### PR TITLE
migrate: 修正 SCSS、i18n 文字內容與語言切換顯示

### DIFF
--- a/assets/css/components/carousel.scss
+++ b/assets/css/components/carousel.scss
@@ -59,13 +59,13 @@ img.reload {
                 font-weight: 600;
 
                 &:hover {
-                    background-color: rgb(0, 0, 0);
+                    background-color: rgba(0, 0, 0, 1);
                 }
 
                 &:focus {
                     padding: 4px;
                     border: 2px solid #fff;
-                    background-color: rgb(0, 0, 0);
+                    background-color: rgba(0, 0, 0, 1);
                     outline: none;
                     color: #fff;
                 }
@@ -80,7 +80,7 @@ img.reload {
                 border: 0 solid transparent;
 
                 &:hover {
-                    background-color: rgb(0, 0, 0);
+                    background-color: rgba(0, 0, 0, 1);
                 }
             }
 

--- a/assets/css/reset.scss
+++ b/assets/css/reset.scss
@@ -4,11 +4,11 @@
 
 *:not(article) {
   > h1, > h2, > h3, > h4, > h5, > h6 {
+    margin: 0;
 
     &:not(article &) {
       font-size: inherit;
     }
-    margin: 0;
   }
 }
 

--- a/assets/css/typography.scss
+++ b/assets/css/typography.scss
@@ -1,22 +1,6 @@
 @import 'utilities/px-to-rem';
 
 :root {
-  &:lang(zh) {
-    --body-font-family: helvetica, 'Noto Sans TC', system-ui, sans-serif;
-  }
-  &:lang(en) {
-    --body-font-family: helvetica, system-ui, sans-serif;
-  }
-  &:lang(ja) {
-    --body-font-family: helvetica, 'Noto Sans JP', system-ui, sans-serif;
-  }
-  &:lang(th) {
-    --body-font-family: helvetica, 'Noto Sans Thai', system-ui, sans-serif;
-  }
-  &:lang(vi) {
-    --body-font-family: inter, system-ui, sans-serif;
-  }
-
   --body-line-height: 1.7em;
   --body-font-size: #{px-to-rem(16px)};
 
@@ -44,6 +28,22 @@
 
   --h1-font-size: #{px-to-rem(36px)};
   --h1-font-weight: 600;
+
+  &:lang(zh) {
+    --body-font-family: helvetica, 'Noto Sans TC', system-ui, sans-serif;
+  }
+  &:lang(en) {
+    --body-font-family: helvetica, system-ui, sans-serif;
+  }
+  &:lang(ja) {
+    --body-font-family: helvetica, 'Noto Sans JP', system-ui, sans-serif;
+  }
+  &:lang(th) {
+    --body-font-family: helvetica, 'Noto Sans Thai', system-ui, sans-serif;
+  }
+  &:lang(vi) {
+    --body-font-family: inter, system-ui, sans-serif;
+  }
 }
 
 a {

--- a/content/components/button-and-link/_index.md
+++ b/content/components/button-and-link/_index.md
@@ -5,7 +5,7 @@ maturity: "alpha"
 
 ### 常見按鈕
 
-{{< live-example partial="ctas/button.html" i18n_selector="button" i18n="en-US:Submit,Delete,Cancel;ja:送信,削除,キャンセル;vi:Gửi,Xóa,Hủy;th:ส่ง,ลบ,ยกเลิก" >}}
+{{< live-example partial="ctas/button.html" i18n_selector="button" i18n="en-US:Submit,Delete,Next;ja:送信,削除,キャンセル;vi:Gửi,Xóa,Hủy;th:ส่ง,ลบ,ยกเลิก" >}}
 
 #### CSS
 

--- a/content/components/form/_index.md
+++ b/content/components/form/_index.md
@@ -5,7 +5,7 @@ maturity: "alpha"
 
 ### 簡易欄位
 
-{{< live-example partial="form/form-elements.html" i18n_selector="[for=name],[for=city],[for=desc],[for=select],[for=taipei],[for=newtaipei],[for=keelung]" i18n="en-US:Full name,City of residence,Description,Select,Taipei,New Taipei,Keelung" >}}
+{{< live-example partial="form/form-elements.html" i18n_selector="[for=name],[for=city],[for=desc],[value='select'],[value=taipei],[value=newtaipei],[value=keelung]" i18n="en-US:Full name,City of residence,Description,Select,Taipei,New Taipei,Keelung" >}}
 
 #### CSS
 
@@ -33,7 +33,7 @@ maturity: "alpha"
 
 ### 欄位說明
 
-{{< live-example partial="form/field.html" i18n_selector="label,.field-description li" i18n="en-US:Email,Address must end with @pdis.nat.gov.tw.;" >}}
+{{< live-example partial="form/field.html" i18n_selector="label,.field-description li" i18n="en-US:Email,Address must end with @pdis.nat.gov.tw." >}}
 
 #### CSS
 
@@ -45,7 +45,7 @@ maturity: "alpha"
 
 ### 必要欄位
 
-{{< live-example partial="form/field-required.html" i18n_selector="label,.field-required" i18n="en-US:Email,required;" >}}
+{{< live-example partial="form/field-required.html" i18n_selector="label,.field-required" i18n="en-US:Email,required" >}}
 
 #### 親和力
 

--- a/content/components/form/_index.md
+++ b/content/components/form/_index.md
@@ -5,7 +5,7 @@ maturity: "alpha"
 
 ### 簡易欄位
 
-{{< live-example partial="form/form-elements.html" i18n_selector="[for=name],[for=city],[for=desc]" i18n="en-US:Full name,City of residence,Description" >}}
+{{< live-example partial="form/form-elements.html" i18n_selector="[for=name],[for=city],[for=desc],[for=select],[for=taipei],[for=newtaipei],[for=keelung]" i18n="en-US:Full name,City of residence,Description,Select,Taipei,New Taipei,Keelung" >}}
 
 #### CSS
 

--- a/content/components/form/_index.md
+++ b/content/components/form/_index.md
@@ -23,7 +23,7 @@ maturity: "alpha"
 
 ### 選項欄位
 
-{{< live-example partial="form/form-checkable.html" i18n_selector="[for=id],[for=items]" i18n="en-US:ID type,Lost document replacement" >}}
+{{< live-example partial="form/form-checkable.html" i18n_selector="[for=id],[for=items],[for=v-healthid],[for=v-moica],[for=v-phone],[for=check-h-healthid],[for=check-h-moica],[for=check-h-id]" i18n="en-US:ID type,Lost document replacement,NHI Card,Digital Certificate,Cell phone,NHI Card,Digital Certificate,ID Card" >}}
 
 #### CSS
 

--- a/layouts/_partials/example.html
+++ b/layouts/_partials/example.html
@@ -8,7 +8,7 @@
     }}
     <select
       aria-label="語言選擇"
-      data-i18n-selector="{{ .i18n_selector }}"
+      data-i18n-selector="{{ $.i18n_selector }}"
       class="field-select absolute nt2 lh-solid pa1 right-0 mr4 top-0 f7 pointer"
     >
       <option value="default">正體中文</option>

--- a/layouts/_partials/example.html
+++ b/layouts/_partials/example.html
@@ -14,7 +14,7 @@
       <option value="default">正體中文</option>
       {{ range $i18n }} {{ $parts := split . ":" }}
       <option lang="{{ index $parts 0 }}" data-phrases="{{ index $parts 1 }}">
-        {{ index $.Site.Params.i18n.langs (index $parts 0) }}
+        {{ index $.context.Site.Params.i18n.langs (index $parts 0) }}
       </option>
       {{ end }}
     </select>

--- a/layouts/_partials/form/form-elements.html
+++ b/layouts/_partials/form/form-elements.html
@@ -6,10 +6,10 @@
   <fieldset class="fieldset">
     <label for="city" class="field-label">居住城市</label>
     <select class="field-input" id="city">
-      <option for="select">選擇</option>
-      <option for="taipei">台北市</option>
-      <option for="newtaipei">新北市</option>
-      <option for="keelung">基隆市</option>
+      <option value="select">選擇</option>
+      <option value="taipei">台北市</option>
+      <option value="newtaipei">新北市</option>
+      <option value="keelung">基隆市</option>
     </select>
   </fieldset>
   <fieldset class="fieldset">

--- a/layouts/_shortcodes/live-example.html
+++ b/layouts/_shortcodes/live-example.html
@@ -7,4 +7,4 @@
 {{ if eq $customElement "true" }}{{ $inject_data = $raw_content | base64Encode }}{{ end }}
 {{ $rendered_content := cond (eq $customElement "true") "" (partial $partial_name .) }}
 {{ $code_content := cond (eq $customElement "true") $raw_content $rendered_content }}
-{{ partial "example.html" (dict "rendered_content" $rendered_content "raw_content" $code_content "inject_html_data" $inject_data "context" .) }}
+{{ partial "example.html" (dict "rendered_content" $rendered_content "raw_content" $code_content "inject_html_data" $inject_data "i18n" (.Get "i18n") "i18n_selector" (.Get "i18n_selector") "context" .) }}


### PR DESCRIPTION
  ## 變更內容

  本 PR 包含三類修正，均從  Jekyll 版本遷移至 Hugo：

  ### 1. SCSS 相容性修正
  - `carousel.scss`：將 `rgb(0 0 0 / %)` 現代語法改為 `rgba()` 相容語法
  - `reset.scss`：將 `margin: 0` 移至 nested rule 之前，修正 Sass Deprecation Warning
  - `typography.scss`：將 `&:lang()` 區塊移至 `:root` 結尾處，同上

  ### 2. i18n 文字內容修正
  - `button-and-link`：英文版第三顆按鈕文字 `Cancel` → `Next`
  - `checkable`：英文版新增 Authentication method、TW FidO authentication 等翻譯；`Health card ID` 更正為 `NHI Card`
  - `form`：選項欄位與簡易欄位的英文 i18n 選擇器與翻譯擴充（NHI Card、Taipei、New Taipei、Keelung 等）

  ### 3. Live Example 語言切換功能修正（Hugo 端 bug）
  - `live-example.html` shortcode 未將 `i18n`、`i18n_selector` 傳入 `example.html`，導致語言選擇器完全不顯示
  - `example.html` 在 `with .i18n` 區塊內取不到 Site 參數，導致語言選項名稱空白