### PR TITLE
fix(config): 允許 content 目錄的 HTML 頁面通過 Hugo 安全政策

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -4,6 +4,9 @@ title = "政府網站設計原則"
 timezone = "Asia/Taipei"
 uglyURLs = true
 
+[security]
+  allowContent = ['^text/html$', '^text/markdown$']
+
 [sass]
   [sass.defaults]
     outputStyle = "compressed"


### PR DESCRIPTION
## 問題
  CI build 在 Hugo 升級後失敗，錯誤如下：
  > access denied: "text/html" is not whitelisted in policy "security.allowContent"

  導致 `content/` 內 10 個 `.html` 頁面（無障礙示範頁、skip-to、landmark、digital-info 等）無法產生，整站 build 中斷。

  ## 原因
  - Hugo **v0.162.0** 新增安全政策 `security.allowContent`，預設值 `['! ^text/html$']` 會**禁止**把 `content/` 內的 `.html`
  當成頁面（理由：HTML 會原樣輸出，可能夾帶任意 JS）。
  - CI workflow 使用 `hugo-version: "latest"`，因此自動抓到含此預設的新版 Hugo。
  - 本專案的 `.html` 頁面是**刻意設計**的互動示範，與該政策針對的「不受信任外部內容」情境不同。

  ## 變更
  `hugo.toml` 新增：

  ```toml
  [security]
     allowContent = ['^text/html$', '^text/markdown$']
  ```

  放行所有 content 型別，讓既有 .md（38 個）與 .html（10 個）頁面正常產生。

  安全考量

  此政策防的是「build 吃進不受信任內容、原樣輸出 HTML/JS」的情境。本專案所有內容皆為團隊自寫、commit 進 git、經 PR review
  的第一方內容，無外部注入管道，故放行 HTML 在此 trust model 下無實際風險；此設定等同還原 v0.162 之前的既有行為。