### PR TITLE
ci(lighthouse): 自動探索編譯後頁面並聚焦無障礙把關

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -5,12 +5,15 @@ on:
 
   # Triggers the workflow when pull request is opened or updated
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
+
+# Cancel an in-progress run for the same PR/branch when a new commit arrives
+concurrency:
+  group: lighthouse-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lighthouseci:
-    # Run this job if labeled with 'ci-lighthouse'
-    if: ${{ github.event.label.name == 'ci-lighthouse' }}
     runs-on: ubuntu-latest
     steps:
       #ref: https://github.com/actions/starter-workflows/tree/main/pages

--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -11,6 +11,9 @@ on:
       - 'content/**'
       - 'layouts/**'
       - 'static/js/**'
+      - '.github/workflows/lhci.yml'
+      - '.lighthouserc.json'
+      - 'hugo.toml'
 
 # Cancel an in-progress run for the same PR/branch when a new commit arrives
 concurrency:

--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -6,6 +6,11 @@ on:
   # Triggers the workflow when pull request is opened or updated
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'assets/**'
+      - 'content/**'
+      - 'layouts/**'
+      - 'static/js/**'
 
 # Cancel an in-progress run for the same PR/branch when a new commit arrives
 concurrency:
@@ -20,8 +25,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # Fall back to the triggering ref/repo when not run from a pull request
+          # (e.g. manual workflow_dispatch), where github.event.pull_request is empty
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
@@ -35,7 +42,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install -g @lhci/cli@0.11.x
+      - run: npm install -g @lhci/cli@0.15.x
       # Collect Lighthouse results
       - run: lhci autorun
         env:

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -4,6 +4,7 @@
       "numberOfRuns": 1,
       "staticDistDir": "./public",
       "maxAutodiscoverUrls": 0,
+      "staticDirFileDiscoveryDepth": 4,
       "autodiscoverUrlBlocklist": [
         "http://localhost/categories/index.html",
         "http://localhost/tags/index.html",
@@ -18,24 +19,11 @@
       }
     },
     "assert": {
-      "preset": "lighthouse:no-pwa",
       "assertions": {
         "categories:performance": ["warn", { "minScore": 0.9 }],
         "categories:accessibility": ["error", { "minScore": 1 }],
-        "csp-xss": "warn",
-        "is-crawlable": "warn",
-        "meta-description": "warn",
-        "unminified-css": "warn",
-        "unused-css-rules": "warn",
-        "uses-text-compression": "warn",
-        "unused-javascript": "warn",
-        "unminified-javascript": "warn",
-        "unsized-images": "warn",
-        "errors-in-console": "warn",
-        "crawlable-anchors": "warn",
-        "inspector-issues": "warn",
-        "uses-optimized-images": "warn",
-        "uses-responsive-images": "warn"
+        "categories:best-practices": ["warn"],
+        "categories:seo": ["warn"]
       }
     },
     "upload": {

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -2,32 +2,16 @@
   "ci": {
     "collect": {
       "numberOfRuns": 1,
-      "startServerCommand": "hugo server --environment production",
-      "url": [
-        "http://localhost:1313/",
-        "http://localhost:1313/accessibility-statement.html",
-        "http://localhost:1313/contact.html",
-        "http://localhost:1313/components/",
-        "http://localhost:1313/components/landmark/",
-        "http://localhost:1313/components/checkable/",
-        "http://localhost:1313/components/button-and-link/",
-        "http://localhost:1313/components/digital-info/",
-        "http://localhost:1313/components/form/",
-        "http://localhost:1313/components/official-document/",
-        "http://localhost:1313/components/skip-to/",
-        "http://localhost:1313/components/table/",
-        "http://localhost:1313/components/textarea/",
-        "http://localhost:1313/components/warning-text/",
-        "http://localhost:1313/components/accordion/",
-        "http://localhost:1313/components/tabs/",
-        "http://localhost:1313/technology/",
-        "http://localhost:1313/technology/anti_patterns/",
-        "http://localhost:1313/technology/internationalization/",
-        "http://localhost:1313/technology/progressive_enhancement/",
-        "http://localhost:1313/visual/",
-        "http://localhost:1313/visual/colors/",
-        "http://localhost:1313/visual/internationalization/",
-        "http://localhost:1313/visual/typography/"
+      "staticDistDir": "./public",
+      "maxAutodiscoverUrls": 0,
+      "autodiscoverUrlBlocklist": [
+        "http://localhost/categories/index.html",
+        "http://localhost/tags/index.html",
+        "http://localhost/components/landmark/blank.html",
+        "http://localhost/components/landmark/one-column.html",
+        "http://localhost/components/skip-to/skip-to.html",
+        "http://localhost/components/skip-to/skip-to-multiple.html",
+        "http://localhost/components/digital-info/digital-info.html"
       ],
       "settings": {
         "preset": "desktop"
@@ -43,7 +27,15 @@
         "meta-description": "warn",
         "unminified-css": "warn",
         "unused-css-rules": "warn",
-        "uses-text-compression": "warn"
+        "uses-text-compression": "warn",
+        "unused-javascript": "warn",
+        "unminified-javascript": "warn",
+        "unsized-images": "warn",
+        "errors-in-console": "warn",
+        "crawlable-anchors": "warn",
+        "inspector-issues": "warn",
+        "uses-optimized-images": "warn",
+        "uses-responsive-images": "warn"
       }
     },
     "upload": {

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -5,8 +5,8 @@
       "startServerCommand": "hugo server --environment production",
       "url": [
         "http://localhost:1313/",
-        "http://localhost:1313/accessibility-statement/",
-        "http://localhost:1313/contact/",
+        "http://localhost:1313/accessibility-statement.html",
+        "http://localhost:1313/contact.html",
         "http://localhost:1313/components/",
         "http://localhost:1313/components/landmark/",
         "http://localhost:1313/components/checkable/",

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -28,7 +28,7 @@
   <div class="ph2 tc w-100" style="flex: 1 1 calc(33.333% - 2rem)">
     <a class="db" {{ with $doc }}href="{{ .RelPermalink }}" {{ end }}>
       <div class="w-70 center">
-        <img src="{{ $svgPath | relURL }}" alt="{{ .Title }}" />
+        <img src="{{ $svgPath | relURL }}" alt="" />
       </div>
       <div class="mt3">{{ .Title }}</div>
     </a>


### PR DESCRIPTION
## 背景

目前 Lighthouse CI 的設定有幾個維護問題：

- 受測頁面需手動維護 URL 清單，新增頁面後容易漏掉
- PR 需要額外加上特定 label 才會觸發，流程不夠直覺
- 同一個 PR 連續 push 時，舊的 Lighthouse job 不會自動取消
- 使用較舊版本的 LHCI，無法設定較深層的靜態檔案探索
- 升級到 Lighthouse 12 後，首頁有 1 個新的無障礙稽核項目需要修正

## 這次變更

### 1. 改為針對編譯後靜態頁面自動探索

- 將 Lighthouse 收集模式改為掃描 `public/` 編譯產物，而非啟動開發伺服器後手動指定 URL
- 啟用自動探索全部頁面（`maxAutodiscoverUrls: 0`）
- 補上 `staticDirFileDiscoveryDepth: 4`，避免深層頁面漏掃
- 保留 blocklist，排除分類頁、標籤頁，以及部分僅供 iframe/demo 使用、不適合納入正式無障礙把關的頁面

### 2. 將 CI gate 聚焦在 accessibility

- `accessibility` 維持 error，要求分數必須是 `1.0`
- `performance`、`best-practices`、`seo` 改為 warning
- 讓 Lighthouse CI 的失敗訊號更聚焦在這次真正要把關的無障礙品質，而不是被非關鍵項目阻擋 merge

### 3. 調整 GitHub Actions 觸發條件

- 移除必須加上 `ci-lighthouse` label 才執行的限制
- 改為 PR 開啟、重新開啟、或有新 commit 時自動執行
- 加入 concurrency 設定，當同一個 PR 有新 commit 時，自動取消前一次尚未跑完的 Lighthouse 工作
- 加入 path filter，只有在以下路徑有變更時才執行 Lighthouse：
  - `assets/**`
  - `content/**`
  - `layouts/**`
  - `static/js/**`

### 4. 修正手動執行時的 checkout 問題

- 補上 `workflow_dispatch` 情境的 fallback ref / repository 設定
- 避免手動觸發時因為 `pull_request` 欄位不存在而導致 checkout 失敗

### 5. 升級 LHCI 版本

- 將 `@lhci/cli` 由 `0.11.x` 升級到 `0.15.x`
- 取得較新的 Lighthouse 核心版本（12.6.1）與 `staticDirFileDiscoveryDepth` 支援

### 6. 修正首頁無障礙問題

- 配合 Lighthouse 12 的 `image-redundant-alt` 稽核，將首頁三張功能圖示改為裝飾性圖片處理（空 `alt`）
- 避免圖片的 `alt` 文字與同一連結中的可見文字重複，造成螢幕閱讀器重複朗讀

## 驗證結果

- 使用 LHCI `0.15.x` 本機重跑驗證
- 成功探索 **44** 個頁面，blocklist 設定正常生效
- 所有頁面 accessibility 分數皆為 `1.00`
- `lhci assert` 最終通過，exit code 為 `0`

## 影響

- Lighthouse CI 會更接近實際站點輸出的靜態結果
- 新增頁面時不需要再手動維護 URL 清單
- PR 流程更直覺，不必依賴額外 label
- 不相關的 PR 不會白跑 Lighthouse，能減少 CI 資源浪費
- CI failure 訊號會更集中在真正需要強制把關的無障礙問題上