### PR TITLE
feat: 新增 AI 對話元件——即時宣告、對話容器、訊息氣泡、輸入中提示

### DIFF
--- a/assets/css/components/chat-container.scss
+++ b/assets/css/components/chat-container.scss
@@ -1,0 +1,104 @@
+// Chat Container 元件樣式
+// 容器語意（role="log" + aria-labelledby + tabindex="0"）由 HTML 提供，本檔僅處理視覺
+// 相對單位為主，確保 200% 文字放大與 reflow 不破版
+// 角色區分不只靠視覺：訊息內含 visually-hidden 角色前綴，並輔以左右對齊
+
+.chat-container {
+  background-color: var(--backgroundColor);
+  border: 1px solid var(--borderColor);
+  border-radius: 0.375rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 20rem;
+  overflow-y: auto;
+  padding: 1rem;
+  scroll-behavior: smooth;
+
+  @media (prefers-reduced-motion: reduce) {
+    scroll-behavior: auto;
+  }
+
+  // 鍵盤聚焦容器捲動時的可見 focus ring（沿用 repo 慣例）
+  &:focus-visible {
+    outline: 3px solid var(--linkColor);
+    outline-offset: 2px;
+  }
+}
+
+// 「捲到最新訊息」按鈕：絕對定位浮在 log 底部之上，避免出現時造成版面位移
+// 圖示＋可見文字（非純圖示）：可及名稱＝可見文字（WCAG 2.5.3 Label in Name）
+.chat-container__jump-latest {
+  align-items: center;
+  animation: chat-container-jump-in 0.2s ease;
+  background-color: var(--backgroundColorLayer1);
+  border: 1px solid var(--borderColor);
+  border-radius: 1.375rem;
+  bottom: 0.75rem;
+  color: var(--textColor);
+  cursor: pointer;
+  display: inline-flex;
+  gap: 0.375rem;
+  justify-content: center;
+  left: 50%;
+  min-height: 2.75rem;
+  padding: 0 1rem;
+  position: absolute;
+  transform: translateX(-50%);
+  z-index: 1;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+
+  // display: inline-flex 會蓋過 hidden 屬性的預設樣式，需明確還原
+  &[hidden] {
+    display: none;
+  }
+
+  &:hover {
+    background-color: var(--backgroundColor);
+  }
+
+  &:focus-visible {
+    outline: 3px solid var(--linkColor);
+    outline-offset: 2px;
+  }
+
+  svg {
+    pointer-events: none;
+  }
+}
+
+// 文件示範外框
+.chat-container-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chat-container-demo__heading {
+  margin: 0;
+}
+
+.chat-container-demo__viewport {
+  position: relative;
+}
+
+.chat-container-demo__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+@keyframes chat-container-jump-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 0.25rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}

--- a/assets/css/components/live-announcer.scss
+++ b/assets/css/components/live-announcer.scss
@@ -1,0 +1,71 @@
+// Live Announcer 示範面板樣式（僅文件頁使用；元件本體無視覺輸出）
+// .visually-hidden 由 header.scss 提供，本檔不重複定義
+
+.live-announcer-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.live-announcer-demo__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.live-announcer-demo__title {
+  font-weight: 700;
+  margin: 0;
+}
+
+.live-announcer-demo__log {
+  background-color: var(--backgroundColorLayer1);
+  border: 1px solid var(--borderColor);
+  border-radius: 0.375rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  min-height: 6rem;
+  padding: 1rem;
+}
+
+.live-announcer-demo__item {
+  animation: live-announcer-demo-fade-in 0.3s ease;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+.live-announcer-demo__empty {
+  color: var(--secondaryTextColor);
+}
+
+.live-announcer-demo__level {
+  font-weight: 700;
+}
+
+// 播報全文為每列的主要內容，換行時獨立佔滿一行，不與 level/time 徽章擠在同列
+.live-announcer-demo__message {
+  flex: 1 1 100%;
+}
+
+.live-announcer-demo__time {
+  color: var(--secondaryTextColor);
+  font-variant-numeric: tabular-nums;
+}
+
+@keyframes live-announcer-demo-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}

--- a/assets/css/components/message-bubble.scss
+++ b/assets/css/components/message-bubble.scss
@@ -1,0 +1,81 @@
+// Message Bubble 元件樣式
+// 語意（article + aria-labelledby 可見角色標題）由結構提供；
+// 角色區分不靠視覺：左右對齊與配色僅為輔助
+// 操作列樣式沿用 toolbar.scss（.toolbar / .toolbar__button），本檔只補氣泡內定位
+// 無動畫設計：不做串流游標閃爍與進場動畫，reduced-motion 天然符合
+
+message-bubble {
+  display: block;
+}
+
+.message-bubble__inner {
+  border-radius: 0.75rem;
+  max-width: 85%;
+  padding: 0.75rem 1rem;
+  width: fit-content;
+}
+
+.message-bubble__inner--user {
+  background-color: var(--backgroundColorLayer1);
+  margin-inline-start: auto;
+}
+
+.message-bubble__inner--ai {
+  background-color: var(--backgroundColor);
+  border: 1px solid var(--borderColor);
+}
+
+// .message-bubble__slot-pre 刻意無樣式：保留給正文前置內容（如附件、引用來源）
+// 的擴充插槽，目前僅靠原生 hidden 屬性隱藏；實際內容尚未定義，版面應交由
+// 該內容自行決定，不預先套用固定樣式
+
+.message-bubble__role {
+  font-size: 0.9em;
+  font-weight: 700;
+  margin: 0 0 0.25rem;
+}
+
+.message-bubble__body {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.message-bubble__error {
+  border: 1px solid var(--warningColor);
+  border-radius: 0.375rem;
+  font-weight: 700;
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0.75rem;
+}
+
+// toolbar.scss 的 .toolbar 設了 display: inline-flex，會蓋過 hidden 屬性，需明確還原
+.message-bubble__toolbar {
+  margin-top: 0.5rem;
+
+  &[hidden] {
+    display: none;
+  }
+}
+
+// 文件示範外框
+.message-bubble-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.message-bubble-demo__stage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  &:empty {
+    display: none;
+  }
+}
+
+.message-bubble-demo__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}

--- a/assets/css/components/typing-indicator.scss
+++ b/assets/css/components/typing-indicator.scss
@@ -1,0 +1,87 @@
+// Typing Indicator 元件樣式
+// 動畫節點對輔助科技完全隱藏（JS 掛 aria-hidden="true" 常駐）；
+// 視覺形式為三點 staggered 跳動，僅供人眼判讀「進行中」語意
+// 點色使用 --mutedTextColor（非 --secondaryTextColor，避免與內文用色混用）；
+// 已實測對比：亮色模式 6.26:1／暗色模式 8.92:1，皆通過 WCAG 1.4.11 的 3:1 下限
+
+.typing-indicator {
+  align-items: center;
+  background-color: var(--backgroundColor);
+  border: 1px solid var(--borderColor);
+  border-radius: 0.75rem;
+  display: flex;
+  gap: 0.3rem;
+  padding: 0.75rem 1rem;
+  width: fit-content;
+
+  &[hidden] {
+    display: none;
+  }
+}
+
+.typing-indicator__dot {
+  animation: typing-indicator-bounce 1.2s ease-in-out infinite;
+  background-color: var(--mutedTextColor);
+  border-radius: 50%;
+  height: 0.5rem;
+  width: 0.5rem;
+
+  &:nth-child(2) {
+    animation-delay: 0.15s;
+  }
+
+  &:nth-child(3) {
+    animation-delay: 0.3s;
+  }
+}
+
+// reduced-motion：跳動改為極輕微 opacity 脈動，替換而非移除（保留「進行中」
+// 語意）；若團隊審查偏保守可改回完全靜態，把下面規則改成 animation: none 即可
+@media (prefers-reduced-motion: reduce) {
+  .typing-indicator__dot {
+    animation-duration: 1.8s;
+    animation-name: typing-indicator-pulse;
+  }
+}
+
+@keyframes typing-indicator-bounce {
+  0%, 60%, 100% {
+    transform: translateY(0);
+  }
+
+  30% {
+    transform: translateY(-0.25rem);
+  }
+}
+
+@keyframes typing-indicator-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.4;
+  }
+}
+
+// 文件示範外框
+.typing-indicator-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.typing-indicator-demo__heading {
+  margin: 0;
+}
+
+.typing-indicator-demo__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.typing-indicator-demo__status {
+  color: var(--mutedTextColor);
+  margin: 0;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -25,11 +25,15 @@
 @import "components/modal";
 @import "components/search-feedback";
 @import "components/toolbar";
-@import "components/side-navigation"; 
+@import "components/side-navigation";
 @import "components/tree-view";
 @import "components/pagination";
 @import "components/progress-stepper";
 @import "components/file-upload";
+@import "components/live-announcer";
+@import "components/chat-container";
+@import "components/message-bubble";
+@import "components/typing-indicator";
 
 body,
 button,

--- a/assets/js/demo/chat-container.demo.js
+++ b/assets/js/demo/chat-container.demo.js
@@ -1,0 +1,38 @@
+/**
+ * chat-container.demo.js — 文件頁示範程式（非元件本體）
+ *
+ * 「模擬新訊息」按鈕：輪流以訊息氣泡（<message-bubble>）產生
+ * 使用者／客服訊息，透過容器對外 API appendMessage() 加入 log，
+ * 展示捲動策略。內容一律以 textContent 設定（防 XSS）。
+ */
+
+'use strict';
+
+// 模擬訊息輪播內容（demo 專用）
+const DEMO_MESSAGES = [
+  { variant: 'user', text: '請問可以用信用卡繳納嗎？' },
+  { variant: 'ai', text: '可以，您可透過地方稅網路申報作業網站以信用卡繳納。' },
+  { variant: 'user', text: '逾期繳納會有滯納金嗎？' },
+  { variant: 'ai', text: '會的，每逾 3 日按滯納稅額加徵 1%，最高加徵 10%。' },
+  { variant: 'user', text: '瞭解，謝謝您的協助。' },
+  { variant: 'ai', text: '不客氣，祝您順心！' },
+];
+
+let demoIndex = 0;
+
+document.addEventListener('click', function (event) {
+  const button = event.target.closest('[data-demo-add-message]');
+  if (!button) return;
+
+  const demo = button.closest('[data-chat-demo]');
+  const container = demo ? demo.querySelector('[data-chat-container]') : null;
+  if (!container || !container.chatContainer) return;
+
+  const data = DEMO_MESSAGES[demoIndex % DEMO_MESSAGES.length];
+  demoIndex += 1;
+
+  const bubble = document.createElement('message-bubble');
+  bubble.setAttribute('variant', data.variant);
+  bubble.textContent = data.text;
+  container.chatContainer.appendMessage(bubble);
+});

--- a/assets/js/demo/live-announcer.demo.js
+++ b/assets/js/demo/live-announcer.demo.js
@@ -1,0 +1,59 @@
+/**
+ * live-announcer.demo.js — 文件頁示範程式（非元件本體）
+ *
+ * 監聽 <live-announcer> 每次寫入時 dispatch 的 live-announcer:announced
+ * 事件，把宣告內容同步到可視化「已宣告內容」面板。
+ * 一律使用事件委派：示範內容由 live-example（customElement="true"）
+ * 於頁面載入後注入，不能假設節點在本檔執行時已存在。
+ */
+
+'use strict';
+
+// 等級的文字標籤：面板不可只靠顏色區分等級
+const LEVEL_LABELS = {
+  polite: '【提示】',
+  assertive: '【警示】',
+};
+
+// 測試按鈕 → 呼叫元件 instance method
+document.addEventListener('click', function (event) {
+  const button = event.target.closest('[data-demo-level]');
+  if (!button) return;
+
+  const announcer = document.querySelector('live-announcer');
+  if (!announcer) return;
+
+  const message = button.getAttribute('data-demo-message') || '';
+  if (button.getAttribute('data-demo-level') === 'assertive') {
+    announcer.alert(message);
+  } else {
+    announcer.announce(message);
+  }
+});
+
+// 元件每次實際寫入 region 時，同步 append 一列到面板
+document.addEventListener('live-announcer:announced', function (event) {
+  const log = document.querySelector('[data-demo-log]');
+  if (!log) return;
+
+  const empty = log.querySelector('[data-demo-empty]');
+  if (empty) empty.remove();
+
+  const item = document.createElement('li');
+  item.className = 'live-announcer-demo__item';
+
+  const level = document.createElement('span');
+  level.className = 'live-announcer-demo__level';
+  level.textContent = LEVEL_LABELS[event.detail.level] || '';
+
+  const time = document.createElement('span');
+  time.className = 'live-announcer-demo__time';
+  time.textContent = new Date().toLocaleTimeString('zh-TW', { hour12: false });
+
+  const message = document.createElement('span');
+  message.className = 'live-announcer-demo__message';
+  message.textContent = event.detail.message;
+
+  item.append(level, time, message);
+  log.append(item);
+});

--- a/assets/js/demo/message-bubble.demo.js
+++ b/assets/js/demo/message-bubble.demo.js
@@ -1,0 +1,67 @@
+/**
+ * message-bubble.demo.js — 文件頁示範程式（非元件本體）
+ *
+ * 「模擬 AI 回覆」：先加入一則使用者訊息，顯示 typing-indicator 等待動畫；
+ * 等其 typing-indicator:announced 事件確認「AI 正在輸入」已實際送達，
+ * 才動態建立 streaming 狀態的 AI 氣泡，以 setInterval 逐段
+ * appendToken() → complete()，展示逐字渲染、分句播報與完成後操作列
+ * 出現的完整流程。
+ *
+ * 等送達才開始串流：typing-indicator 與訊息氣泡的分句播報共用同一個
+ * polite 頻道，時間相近的呼叫，後者會覆蓋前者；若串流一啟動就有完整句
+ * 可以 flush，會跟尚未送達的「正在輸入」搶頻道並蓋掉它。真實串接時
+ * 「正在輸入」到首個 token 之間通常隔著模型延遲，遠大於本元件的送達
+ * 時間窗，此處等待只是把 demo 的人造時序拉回貼近真實情況。
+ */
+
+'use strict';
+
+const DEMO_USER_TEXT = '請問自然人憑證的工本費是多少？';
+const DEMO_REPLY = '您好！自然人憑證工本費為新臺幣 250 元。憑證有效期限為 5 年，到期前可透過內政部憑證管理中心網站線上展期；展期免費。若還有其他問題，歡迎隨時詢問！';
+const CHUNK_SIZE = 3; // 每段模擬 token 的字元數
+const CHUNK_INTERVAL = 120; // 模擬 token 間隔（ms）
+
+document.addEventListener('click', function (event) {
+  const startButton = event.target.closest('[data-mb-start]');
+  if (!startButton) return;
+
+  const demo = startButton.closest('[data-mb-demo]');
+  const stage = demo ? demo.querySelector('[data-mb-stage]') : null;
+  const indicator = demo ? demo.querySelector('[data-typing-indicator]') : null;
+  if (!stage || !indicator || !indicator.typingIndicator) return;
+
+  startButton.disabled = true;
+
+  const userBubble = document.createElement('message-bubble');
+  userBubble.setAttribute('variant', 'user');
+  userBubble.textContent = DEMO_USER_TEXT;
+  stage.append(userBubble);
+  stage.append(indicator); // 移到使用者訊息之後，示意「等待中」的位置
+
+  function streamReply() {
+    const aiBubble = document.createElement('message-bubble');
+    aiBubble.setAttribute('variant', 'ai');
+    aiBubble.setAttribute('streaming', '');
+    stage.append(aiBubble);
+
+    let offset = 0;
+    const timer = setInterval(function () {
+      if (offset >= DEMO_REPLY.length) {
+        clearInterval(timer);
+        aiBubble.complete();
+        startButton.disabled = false;
+        return;
+      }
+      aiBubble.appendToken(DEMO_REPLY.slice(offset, offset + CHUNK_SIZE));
+      offset += CHUNK_SIZE;
+    }, CHUNK_INTERVAL);
+  }
+
+  const onAnnounced = function () {
+    indicator.removeEventListener('typing-indicator:announced', onAnnounced);
+    indicator.typingIndicator.hide();
+    streamReply();
+  };
+  indicator.addEventListener('typing-indicator:announced', onAnnounced);
+  indicator.typingIndicator.show();
+});

--- a/assets/js/demo/typing-indicator.demo.js
+++ b/assets/js/demo/typing-indicator.demo.js
@@ -1,0 +1,37 @@
+/**
+ * typing-indicator.demo.js — 文件頁示範程式（非元件本體）
+ *
+ * 「模擬等待回覆」：show() 後 3 秒呼叫 hide()，可快速連按驗證 show() 冪等
+ * （面板只會看到恰一次【提示】AI 正在輸入）。狀態文字只給人眼看，不掛
+ * 任何 live 屬性，實際播報內容一律以「已宣告內容」面板為準。
+ *
+ * 防閃爍機制（回覆在延遲出現的 300ms 門檻內就抵達時不顯示、不宣告）不
+ * 額外做成互動按鈕：「按了什麼都不發生」的示範即使配旁白仍然反直覺，
+ * 容易被誤認為故障；這段行為改以 _index.md 的文字說明，並由元件測試
+ * 直接呼叫 API 驗證。
+ */
+
+'use strict';
+
+const SIMULATED_WAIT = 3000; // 模擬回覆延遲（ms），僅供文件示範
+
+function setStatus(demo, text) {
+  const status = demo.querySelector('[data-ti-status]');
+  if (status) status.textContent = text;
+}
+
+document.addEventListener('click', function (event) {
+  const startButton = event.target.closest('[data-ti-start]');
+  if (!startButton) return;
+
+  const demo = event.target.closest('[data-ti-demo]');
+  const indicator = demo ? demo.querySelector('[data-typing-indicator]') : null;
+  if (!indicator || !indicator.typingIndicator) return;
+
+  indicator.typingIndicator.show();
+  setStatus(demo, '已送出請求，回應將於 3 秒後抵達');
+  setTimeout(function () {
+    indicator.typingIndicator.hide();
+    setStatus(demo, '回應已抵達');
+  }, SIMULATED_WAIT);
+});

--- a/content/components/ai/_index.md
+++ b/content/components/ai/_index.md
@@ -1,0 +1,12 @@
+---
+title: AI 元件 (AI Components)
+---
+
+AI 對話介面的共用元件，可依服務需求單獨或組合使用。
+
+### 元件清單
+
+- [即時宣告 (Live Announcer)]({{< ref "components/ai/live-announcer/_index.md" >}})
+- [對話容器 (Chat Container)]({{< ref "components/ai/chat-container/_index.md" >}})
+- [訊息氣泡 (Message Bubble)]({{< ref "components/ai/message-bubble/_index.md" >}})
+- [輸入中提示 (Typing Indicator)]({{< ref "components/ai/typing-indicator/_index.md" >}})

--- a/content/components/ai/chat-container/_index.md
+++ b/content/components/ai/chat-container/_index.md
@@ -1,0 +1,57 @@
+---
+title: 對話容器 (Chat Container)
+maturity: "new"
+---
+
+### 靜態對話
+
+{{< live-example partial="ai/chat-container/basic.html" source="ai/chat-container/basic-source.html" >}}
+
+- 容器使用 `role="log"`，新加入的訊息由螢幕閱讀器自動朗讀（polite），無需設定 `aria-live`。
+- 未使用螢幕閱讀器時，Tab 聚焦容器後可用方向鍵、PageUp／PageDown、Home／End 捲動；螢幕閱讀器使用者請以閱讀游標瀏覽訊息。
+- 本頁 demo 使用簡潔形式 `<message-bubble variant="…">文字</message-bubble>`（由 JS 建構完整結構）；正式使用建議伺服器渲染完整結構，以保留無 JS 降級與可見角色標題，寫法參照[訊息氣泡]({{< ref "components/ai/message-bubble/_index.md" >}})說明頁。
+
+### 動態訊息與捲動策略
+
+{{< live-example partial="ai/chat-container/dynamic.html" source="ai/chat-container/dynamic-source.html" >}}
+
+- 捲動位置在底部時，新訊息自動捲到底；上捲閱讀歷史時不打斷，改顯示「捲到最新訊息」按鈕。
+- 「模擬新訊息」按鈕僅供文件示範。
+
+#### 使用方式
+
+{{< code-example content=`const container = document.querySelector('[data-chat-container]');
+container.chatContainer.appendMessage(node); // 將訊息節點加入末端並依捲動策略處理` >}}
+
+#### CSS
+
+- `.chat-container`：對話容器本體；訊息子節點可為任意元素，示範使用[訊息氣泡]({{< ref "components/ai/message-bubble/_index.md" >}})。
+- `.chat-container__jump-latest`：「捲到最新訊息」按鈕，需放在 log 元素外。
+
+#### 親和力
+
+- log 需有可及名稱：`aria-labelledby` 指向可見標題。
+- 新訊息永不搶焦點；視覺捲動與鍵盤焦點分離。
+- 容器 `tabindex="0"` 讓鍵盤使用者可聚焦捲動，聚焦時有可見 focus ring。
+- 訊息的角色標示（「你」「客服助理」）由訊息氣泡元件以可見文字提供，角色區分不僅依賴視覺。
+
+#### JavaScript
+
+元件以 ES module 撰寫，載入必須加 `type="module"`。（若因架構需要跨網域載入，伺服器須提供 CORS 標頭，否則會靜默失敗。）路徑請依實際部署位置調整。
+
+{{< code-example content=`<script type="module" src="js/components/chat-container.js"></script>` >}}
+
+- 使用 [`chat-container.js`]({{< relURL "js/components/chat-container.js" >}})，自動初始化所有 `[data-chat-container]`。
+- 自動初始化僅涵蓋腳本載入當時已存在的 `[data-*]` 節點；動態插入的情境請先於 DOM 備妥節點再載入腳本。
+- 無 JS 時：靜態訊息仍可讀、容器聚焦後仍可鍵盤捲動；「捲到最新訊息」按鈕不會出現。
+
+#### 參考
+
+- [log role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/log_role) - MDN
+- [ARIA23: Using role=log to identify sequential information updates](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA23) - W3C
+- [Accessible notifications with ARIA Live Regions (Part 2)](https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-2/) - Sara Soueidan
+
+{{< asset-script "js/components/live-announcer.js" >}}
+{{< asset-script "js/components/message-bubble.js" >}}
+{{< asset-script "js/components/chat-container.js" >}}
+{{< asset-script "js/demo/chat-container.demo.js" >}}

--- a/content/components/ai/live-announcer/_index.md
+++ b/content/components/ai/live-announcer/_index.md
@@ -1,0 +1,55 @@
+---
+title: 即時宣告 (Live Announcer)
+maturity: "new"
+---
+
+### 基本示範
+
+{{< live-example partial="ai/live-announcer/basic.html" source="ai/live-announcer/basic-source.html" >}}
+
+- `<live-announcer>` 本體無任何視覺輸出，訊息寫入隱藏的 live region 由螢幕閱讀器朗讀。
+- 「已宣告內容」面板僅供文件示範，非元件功能。
+
+#### Custom Element
+
+- 使用 [`<live-announcer>`]({{< relURL "js/components/live-announcer.js" >}})。
+
+#### 使用方式
+
+頁面所需的靜態標記僅此一行（其餘為示範按鈕與面板，非元件本體）：
+
+{{< code-example content=`<live-announcer></live-announcer>` >}}
+
+{{< code-example content=`const announcer = document.querySelector('live-announcer');
+
+announcer.announce('回覆完成'); // 一般提示（polite）
+announcer.alert('連線中斷，請重新整理頁面'); // 錯誤等必要中斷（assertive）` >}}
+
+#### 親和力
+
+- 請保持宣告訊息簡短、純文字，避免連結、清單或其他複雜結構。
+- assertive 等級的 `alert()` 請僅用於錯誤、逾時等必須立即中斷的情況；其餘請改用 polite 等級的 `announce()`。
+- 請於頁面載入時即掛載 `<live-announcer>`，避免等到要播報時才動態插入。輔助科技通常只會追蹤已存在於 DOM 的 live region，動態插入的區域可能錯過插入後立即發生的第一次播報。
+- 全站僅掛載一個 `<live-announcer>`。
+- 連續呼叫時，本元件會將前一則訊息保留約 1 秒才允許被取代，避免螢幕閱讀器來不及讀取；高頻更新請自行節流，呼叫間隔建議大於 1 秒。
+- 連續兩次呼叫相同文字時，第二次仍會重新播報。
+- 關鍵錯誤建議同時提供可見文字，不要只依賴 `alert()` 的語音播報。
+
+#### JavaScript
+
+元件以 ES module 撰寫，載入必須加 `type="module"`。（若因架構需要跨網域載入，伺服器須提供 CORS 標頭，否則會靜默失敗。）路徑請依實際部署位置調整。
+
+{{< code-example content=`<script type="module" src="js/components/live-announcer.js"></script>` >}}
+
+- 無 JS 時：元件靜默、不影響頁面其他內容。
+- 極端無法取得元件執行個體的環境，可直接對內部 `[data-live-region="polite"]`／`[data-live-region="assertive"]` 節點寫入 `textContent`（最後手段）。
+
+#### 參考
+
+- [ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions) - MDN
+- [Accessible notifications with ARIA Live Regions (Part 1)](https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-1/) - Sara Soueidan
+- [Accessible notifications with ARIA Live Regions (Part 2)](https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-2/) - Sara Soueidan
+- [Are we live?](https://www.scottohara.me/blog/2022/02/05/are-we-live.html) - Scott O'Hara
+
+{{< asset-script "js/components/live-announcer.js" >}}
+{{< asset-script "js/demo/live-announcer.demo.js" >}}

--- a/content/components/ai/message-bubble/_index.md
+++ b/content/components/ai/message-bubble/_index.md
@@ -1,0 +1,98 @@
+---
+title: 訊息氣泡 (Message Bubble)
+maturity: "new"
+---
+
+### 基本氣泡
+
+{{< live-example partial="ai/message-bubble/basic.html" source="ai/message-bubble/basic-source.html" >}}
+
+- 角色標示為可見文字（「你」「客服助理」），`<article>` 以 `aria-labelledby` 指向它。
+- AI 氣泡含操作列：複製、重新生成、讚、倒讚。
+
+### 模擬串流回覆
+
+{{< live-example partial="ai/message-bubble/streaming.html" source="ai/message-bubble/streaming-source.html" >}}
+
+- 送出訊息後先由[輸入中提示]({{< ref "components/ai/typing-indicator/_index.md" >}})元件顯示等待動畫並播報「AI 正在輸入」；等其 `typing-indicator:announced` 事件確認播報已送達，才開始串流。
+- 串流期間正文掛 `aria-hidden="true"`，由本元件依句末標點分句、以至少 1100ms 間隔交由即時宣告代播（節流原因詳見[即時宣告]({{< ref "components/ai/live-announcer/_index.md" >}})頁）；完成時播「回覆完成」並顯示操作列。
+- 「模擬 AI 回覆」按鈕與「已宣告內容」面板僅供文件示範。
+
+#### Custom Element
+
+- 使用 [`<message-bubble>`]({{< relURL "js/components/message-bubble.js" >}})。
+
+#### 使用方式
+
+元件對外只有四個後端無關的方法，任何串流來源都翻譯成這四個呼叫：
+
+{{< code-example content=`const bubble = document.createElement('message-bubble');
+bubble.setAttribute('variant', 'ai');
+bubble.setAttribute('streaming', '');
+container.chatContainer.appendMessage(bubble); // 或直接 append 到任何位置
+
+bubble.appendToken('串流文字片段'); // 追加正文
+bubble.complete();                  // 回覆完成
+bubble.abort();                     // 停止生成（保留已生成部分）
+bubble.error('連線逾時');           // 錯誤（assertive 播報 + 可見錯誤文字）` >}}
+
+後端事件對照範例（**非規範性**，僅為示意）：
+
+{{< code-example content=`// Anthropic Messages API（串流）
+stream.on('content_block_delta', (event) => bubble.appendToken(event.delta.text));
+stream.on('message_stop', () => bubble.complete());` >}}
+
+{{< code-example content=`// OpenAI Responses API（串流）
+for await (const event of stream) {
+  if (event.type === 'response.output_text.delta') bubble.appendToken(event.delta);
+  if (event.type === 'response.completed') bubble.complete();
+}` >}}
+
+角色標題與收尾播報文字可用 `data-*` 屬性覆寫（動態建立與伺服器渲染的靜態氣泡皆支援）：
+
+{{< code-example content=`bubble.setAttribute('data-role-label', '王小明');           // 覆寫角色標題，預設「你」／「客服助理」
+bubble.setAttribute('data-complete-message', '已回覆完畢'); // 覆寫 complete() 結語，預設「回覆完成」
+bubble.setAttribute('data-abort-message', '已取消生成');    // 覆寫 abort() 結語，預設「已停止產生回覆」` >}}
+
+#### CSS
+
+- `.message-bubble__inner`／`__inner--user`／`__inner--ai`：氣泡本體與角色 modifier。
+- `.message-bubble__role`：可見角色標題。
+- `.message-bubble__toolbar`：操作列，樣式沿用工具列元件。
+
+#### 親和力
+
+- 角色標示為可見文字，不靠顏色或對齊區分。
+- 串流正文的播報由「即時宣告」元件分句代播，正文本身不掛任何 `aria-live`。
+- 操作列沿用工具列模式：單一 Tab 停駐點、方向鍵移動。
+- 讚/倒讚為互斥 toggle（`aria-pressed`），再按一次可取消。
+- 操作列按鈕標籤（複製／重新生成／讚／倒讚）、工具列的 `aria-label="訊息操作"`，以及複製失敗時的提示文字，為刻意固定的無障礙輔助文字，目前不提供覆寫。
+
+#### JavaScript
+
+元件以 ES module 撰寫，載入必須加 `type="module"`。（若因架構需要跨網域載入，伺服器須提供 CORS 標頭，否則會靜默失敗。）路徑請依實際部署位置調整。
+
+{{< code-example content=`<script type="module" src="js/components/message-bubble.js"></script>` >}}
+
+- 本元件會自動載入同目錄的 [`toolbar.js`]({{< relURL "js/components/toolbar.js" >}})，部署時需一併放置；頁面需掛載[即時宣告]({{< ref "components/ai/live-announcer/_index.md" >}})元件。
+- 複製成功後有 polite 播報；重新生成與讚/倒讚以 `message-bubble:regenerate`／`message-bubble:feedback` 事件通知外部，元件本體不重送請求。
+- 無 JS 時：靜態氣泡（角色標題、正文）可讀；操作列（含讚/倒讚）維持隱藏。本元件未內建表單模式；若伺服器端支援表單提交，可自行將讚/倒讚改造為表單版本。
+
+#### 多格式文字段落
+
+- 氣泡正文可放入語意化 HTML（如表格、清單）：由伺服器或產品層渲染完成後置入，螢幕閱讀器以原生語意閱讀。
+- `appendToken()` 僅支援純文字；含結構化內容的回覆，建議串流階段以純文字呈現，`complete()` 後由產品層替換正文內容。
+- 即時宣告僅播純文字，表格與清單內容不會透過 live region 朗讀；建議完成時以文字摘要宣告（如「回覆包含表格」），內容由使用者於對話紀錄中瀏覽。
+- 元件不會解析 Markdown；若由呼叫端自行轉換為 HTML 後傳入，該 HTML 須先經過淨化（sanitize）以避免 XSS 風險。
+
+#### 參考
+
+- [Defining 'Toast' Messages](https://adrianroselli.com/2020/01/defining-toast-messages.html) - Adrian Roselli
+- [Accessible notifications with ARIA Live Regions (Part 2)](https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-2/) - Sara Soueidan
+- [Toolbar Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/) - ARIA Authoring Practices Guide
+
+{{< asset-script "js/components/live-announcer.js" >}}
+{{< asset-script "js/components/message-bubble.js" >}}
+{{< asset-script "js/components/typing-indicator.js" >}}
+{{< asset-script "js/demo/message-bubble.demo.js" >}}
+{{< asset-script "js/demo/live-announcer.demo.js" >}}

--- a/content/components/ai/typing-indicator/_index.md
+++ b/content/components/ai/typing-indicator/_index.md
@@ -1,0 +1,53 @@
+---
+title: 輸入中提示 (Typing Indicator)
+maturity: "new"
+---
+
+### 基本示範
+
+{{< live-example partial="ai/typing-indicator/basic.html" source="ai/typing-indicator/basic-source.html" >}}
+
+- 三點跳動動畫表示系統正在處理中。
+- 「已宣告內容」面板僅供文件示範。
+
+#### 使用方式
+
+{{< code-example content=`const typing = document.querySelector('[data-typing-indicator]');
+typing.typingIndicator.show(); // 送出請求時呼叫
+typing.typingIndicator.hide(); // 首段回覆內容抵達時呼叫` >}}
+
+- 播報文案可用 `data-typing-text` 屬性覆寫，預設「AI 正在輸入」。
+- `show()` 有 300ms 延遲出現的防閃爍機制：回應在此窗口內抵達則不顯示、不播報（設計行為，非故障）；`hide()` 一律立即移除視覺，避免與已抵達的回覆內容並存。
+- 若回覆內容也會經由即時宣告播報，建議等本元件發出 `typing-indicator:announced` 事件後再開始傳送內容，避免「正在輸入」被內容播報蓋掉（本頁示範即採此作法）。
+
+#### CSS
+
+- `.typing-indicator`／`__dot`：三點容器與圓點，跳動動畫由 CSS 控制。
+
+#### 親和力
+
+- 動畫節點整體 `aria-hidden="true"` 常駐，不承載任何輔助科技可讀的文字，也無可聚焦子元素；置於對話容器（`role="log"`）內亦不會觸發額外播報。
+- 狀態由[即時宣告]({{< ref "components/ai/live-announcer/_index.md" >}})元件以 polite 等級播報「AI 正在輸入」恰一次；消失不宣告（回覆完成由訊息氣泡負責）。
+- `prefers-reduced-motion: reduce` 下，跳動動畫改為輕微 opacity 脈動，保留「進行中」語意而非直接移除動畫。
+
+#### JavaScript
+
+元件以 ES module 撰寫，載入必須加 `type="module"`。（若因架構需要跨網域載入，伺服器須提供 CORS 標頭，否則會靜默失敗。）路徑請依實際部署位置調整。
+
+{{< code-example content=`<script type="module" src="js/components/typing-indicator.js"></script>` >}}
+
+- 使用 [`typing-indicator.js`]({{< relURL "js/components/typing-indicator.js" >}})，自動初始化所有 `[data-typing-indicator]`，頁面需掛載[即時宣告]({{< ref "components/ai/live-announcer/_index.md" >}})元件。
+- 自動初始化僅涵蓋腳本載入當時已存在的 `[data-*]` 節點；動態插入的情境請先於 DOM 備妥節點再載入腳本。
+- 無 JS 時：節點維持 `hidden`，不出現、不阻斷頁面其他內容。
+
+#### 參考
+
+- [status role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/status_role) - MDN
+- [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) - MDN
+
+{{< asset-script "js/components/live-announcer.js" >}}
+{{< asset-script "js/components/chat-container.js" >}}
+{{< asset-script "js/components/message-bubble.js" >}}
+{{< asset-script "js/components/typing-indicator.js" >}}
+{{< asset-script "js/demo/typing-indicator.demo.js" >}}
+{{< asset-script "js/demo/live-announcer.demo.js" >}}

--- a/layouts/_partials/ai/chat-container/basic-source.html
+++ b/layouts/_partials/ai/chat-container/basic-source.html
@@ -1,0 +1,36 @@
+<!-- 即時宣告元件：全站僅需一個，供訊息氣泡的複製等操作播報使用 -->
+<live-announcer></live-announcer>
+
+<h2 id="chat-log-heading">與客服助理的對話</h2>
+<!-- 外層需建立定位環境（如 position: relative），供下方「捲到最新訊息」按鈕絕對定位 -->
+<div style="position: relative;">
+  <div
+    class="chat-container"
+    role="log"
+    aria-labelledby="chat-log-heading"
+    tabindex="0"
+    data-chat-container
+  >
+    <message-bubble variant="user">你好，我想申請戶籍謄本，需要準備哪些文件？</message-bubble>
+    <message-bubble variant="ai">您好！臨櫃申請戶籍謄本需攜帶國民身分證正本；若委託他人代辦，另需委託書與受託人身分證件。</message-bubble>
+  </div>
+  <button type="button" class="chat-container__jump-latest" hidden data-jump-latest>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <line x1="12" y1="5" x2="12" y2="19"/>
+      <polyline points="19 12 12 19 5 12"/>
+    </svg>
+    <span>捲到最新訊息</span>
+  </button>
+</div>

--- a/layouts/_partials/ai/chat-container/basic.html
+++ b/layouts/_partials/ai/chat-container/basic.html
@@ -1,0 +1,43 @@
+<!-- 即時宣告元件：全站僅需一個，供訊息氣泡的複製等操作播報使用 -->
+<live-announcer></live-announcer>
+
+<div class="chat-container-demo">
+  <h3 id="chat-demo-basic-heading" class="chat-container-demo__heading">與客服助理的對話</h3>
+  <div class="chat-container-demo__viewport">
+    <div
+      class="chat-container"
+      role="log"
+      aria-labelledby="chat-demo-basic-heading"
+      tabindex="0"
+      data-chat-container
+    >
+      <message-bubble variant="user">你好，我想申請戶籍謄本，需要準備哪些文件？</message-bubble>
+      <message-bubble variant="ai">您好！臨櫃申請戶籍謄本需攜帶國民身分證正本；若委託他人代辦，另需委託書與受託人身分證件。</message-bubble>
+      <message-bubble variant="user">可以線上申請嗎？</message-bubble>
+      <message-bubble variant="ai">可以，您可使用自然人憑證至內政部戶政司全球資訊網線上申辦電子戶籍謄本。</message-bubble>
+      <message-bubble variant="user">規費怎麼計算？</message-bubble>
+      <message-bubble variant="ai">臨櫃申請每份新臺幣 15 元；線上申辦電子戶籍謄本免費。</message-bubble>
+      <message-bubble variant="user">好的，謝謝說明。</message-bubble>
+      <message-bubble variant="ai">不客氣，若還有其他問題歡迎隨時詢問。</message-bubble>
+    </div>
+    <button type="button" class="chat-container__jump-latest" hidden data-jump-latest>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <line x1="12" y1="5" x2="12" y2="19"/>
+        <polyline points="19 12 12 19 5 12"/>
+      </svg>
+      <span>捲到最新訊息</span>
+    </button>
+  </div>
+</div>

--- a/layouts/_partials/ai/chat-container/dynamic-source.html
+++ b/layouts/_partials/ai/chat-container/dynamic-source.html
@@ -1,0 +1,33 @@
+<h2 id="chat-log-heading-dynamic">與客服助理的對話</h2>
+<!-- 外層需建立定位環境（如 position: relative），供下方「捲到最新訊息」按鈕絕對定位 -->
+<div style="position: relative;">
+  <div
+    class="chat-container"
+    role="log"
+    aria-labelledby="chat-log-heading-dynamic"
+    tabindex="0"
+    data-chat-container
+  >
+    <message-bubble variant="user">你好，想詢問地價稅的繳納期限。</message-bubble>
+    <message-bubble variant="ai">您好！地價稅開徵期間為每年 11 月 1 日至 11 月 30 日。</message-bubble>
+  </div>
+  <button type="button" class="chat-container__jump-latest" hidden data-jump-latest>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <line x1="12" y1="5" x2="12" y2="19"/>
+      <polyline points="19 12 12 19 5 12"/>
+    </svg>
+    <span>捲到最新訊息</span>
+  </button>
+</div>

--- a/layouts/_partials/ai/chat-container/dynamic.html
+++ b/layouts/_partials/ai/chat-container/dynamic.html
@@ -1,0 +1,38 @@
+<div class="chat-container-demo" data-chat-demo>
+  <h3 id="chat-demo-dynamic-heading" class="chat-container-demo__heading">與客服助理的對話</h3>
+  <div class="chat-container-demo__viewport">
+    <div
+      class="chat-container"
+      role="log"
+      aria-labelledby="chat-demo-dynamic-heading"
+      tabindex="0"
+      data-chat-container
+    >
+      <message-bubble variant="user">你好，想詢問地價稅的繳納期限。</message-bubble>
+      <message-bubble variant="ai">您好！地價稅開徵期間為每年 11 月 1 日至 11 月 30 日。</message-bubble>
+    </div>
+    <button type="button" class="chat-container__jump-latest" hidden data-jump-latest>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <line x1="12" y1="5" x2="12" y2="19"/>
+        <polyline points="19 12 12 19 5 12"/>
+      </svg>
+      <span>捲到最新訊息</span>
+    </button>
+  </div>
+  <!-- 模擬按鈕僅供文件示範：實際應用中訊息由後端串流或使用者送出產生 -->
+  <div class="chat-container-demo__actions">
+    <button type="button" class="button button-primary" data-demo-add-message>模擬新訊息</button>
+  </div>
+</div>

--- a/layouts/_partials/ai/live-announcer/basic-source.html
+++ b/layouts/_partials/ai/live-announcer/basic-source.html
@@ -1,0 +1,2 @@
+<!-- 全站僅需掛載一個 <live-announcer> -->
+<live-announcer></live-announcer>

--- a/layouts/_partials/ai/live-announcer/basic.html
+++ b/layouts/_partials/ai/live-announcer/basic.html
@@ -1,0 +1,29 @@
+<live-announcer></live-announcer>
+
+<div class="live-announcer-demo">
+  <div class="live-announcer-demo__actions">
+    <button
+      type="button"
+      class="button button-primary"
+      data-demo-level="polite"
+      data-demo-message="已找到 12 筆結果"
+    >
+      送出 polite 測試訊息
+    </button>
+    <button
+      type="button"
+      class="button"
+      data-demo-level="assertive"
+      data-demo-message="連線中斷，請重新整理頁面"
+    >
+      送出 assertive 測試訊息
+    </button>
+  </div>
+
+  <!-- 可視化「已宣告內容」面板：僅供文件示範，正式產品不需要。
+       面板不掛任何 live 屬性，避免與元件本體雙重播報。 -->
+  <p class="live-announcer-demo__title">已宣告內容</p>
+  <ol class="live-announcer-demo__log" data-demo-log>
+    <li class="live-announcer-demo__empty" data-demo-empty>尚未有任何宣告</li>
+  </ol>
+</div>

--- a/layouts/_partials/ai/message-bubble/basic-source.html
+++ b/layouts/_partials/ai/message-bubble/basic-source.html
@@ -1,0 +1,48 @@
+<!-- 即時宣告元件：全站僅需一個，供訊息氣泡的複製等操作播報使用 -->
+<live-announcer></live-announcer>
+
+<message-bubble variant="user">
+  <article class="message-bubble__inner message-bubble__inner--user" aria-labelledby="mb-basic-user-role">
+    <p class="message-bubble__role" id="mb-basic-user-role">你</p>
+    <div class="message-bubble__slot-pre" hidden></div>
+    <div class="message-bubble__body">請問如何申請自然人憑證？</div>
+  </article>
+</message-bubble>
+<message-bubble variant="ai">
+  <article class="message-bubble__inner message-bubble__inner--ai" aria-labelledby="mb-basic-ai-role">
+    <p class="message-bubble__role" id="mb-basic-ai-role">客服助理</p>
+    <div class="message-bubble__slot-pre" hidden></div>
+    <div class="message-bubble__body">您好！請攜帶國民身分證正本與健保卡，親至任一戶政事務所申請，工本費為新臺幣 250 元。</div>
+    <p class="message-bubble__error" hidden></p>
+    <!-- 操作列預設 hidden：JS 啟用後才顯示（無 JS 時讚/倒讚等維持隱藏） -->
+    <div class="toolbar message-bubble__toolbar" role="toolbar" aria-label="訊息操作" hidden>
+      <button type="button" class="toolbar__button" data-action="copy" tabindex="0">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+        </svg>
+        <span class="visually-hidden">複製</span>
+      </button>
+      <button type="button" class="toolbar__button" data-action="regenerate" tabindex="-1">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <polyline points="23 4 23 10 17 10"/>
+          <polyline points="1 20 1 14 7 14"/>
+          <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>
+        </svg>
+        <span class="visually-hidden">重新生成</span>
+      </button>
+      <button type="button" class="toolbar__button toolbar__button--toggle" data-action="like" aria-pressed="false" tabindex="-1">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
+        </svg>
+        <span class="visually-hidden">讚</span>
+      </button>
+      <button type="button" class="toolbar__button toolbar__button--toggle" data-action="dislike" aria-pressed="false" tabindex="-1">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/>
+        </svg>
+        <span class="visually-hidden">倒讚</span>
+      </button>
+    </div>
+  </article>
+</message-bubble>

--- a/layouts/_partials/ai/message-bubble/basic.html
+++ b/layouts/_partials/ai/message-bubble/basic.html
@@ -1,0 +1,47 @@
+<div class="message-bubble-demo">
+  <message-bubble variant="user">
+    <article class="message-bubble__inner message-bubble__inner--user" aria-labelledby="mb-basic-user-role">
+      <p class="message-bubble__role" id="mb-basic-user-role">你</p>
+      <div class="message-bubble__slot-pre" hidden></div>
+      <div class="message-bubble__body">請問如何申請自然人憑證？</div>
+    </article>
+  </message-bubble>
+  <message-bubble variant="ai">
+    <article class="message-bubble__inner message-bubble__inner--ai" aria-labelledby="mb-basic-ai-role">
+      <p class="message-bubble__role" id="mb-basic-ai-role">客服助理</p>
+      <div class="message-bubble__slot-pre" hidden></div>
+      <div class="message-bubble__body">您好！請攜帶國民身分證正本與健保卡，親至任一戶政事務所申請，工本費為新臺幣 250 元。</div>
+      <p class="message-bubble__error" hidden></p>
+      <!-- 操作列預設 hidden：JS 啟用後才顯示（無 JS 時讚/倒讚等維持隱藏） -->
+      <div class="toolbar message-bubble__toolbar" role="toolbar" aria-label="訊息操作" hidden>
+        <button type="button" class="toolbar__button" data-action="copy" tabindex="0">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+          </svg>
+          <span class="visually-hidden">複製</span>
+        </button>
+        <button type="button" class="toolbar__button" data-action="regenerate" tabindex="-1">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <polyline points="23 4 23 10 17 10"/>
+            <polyline points="1 20 1 14 7 14"/>
+            <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>
+          </svg>
+          <span class="visually-hidden">重新生成</span>
+        </button>
+        <button type="button" class="toolbar__button toolbar__button--toggle" data-action="like" aria-pressed="false" tabindex="-1">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
+          </svg>
+          <span class="visually-hidden">讚</span>
+        </button>
+        <button type="button" class="toolbar__button toolbar__button--toggle" data-action="dislike" aria-pressed="false" tabindex="-1">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/>
+          </svg>
+          <span class="visually-hidden">倒讚</span>
+        </button>
+      </div>
+    </article>
+  </message-bubble>
+</div>

--- a/layouts/_partials/ai/message-bubble/streaming-source.html
+++ b/layouts/_partials/ai/message-bubble/streaming-source.html
@@ -1,0 +1,12 @@
+<!-- 即時宣告元件：全站僅需一個 -->
+<live-announcer></live-announcer>
+
+<!-- 等待回覆時顯示的輸入中提示，初始 hidden -->
+<div class="typing-indicator" data-typing-indicator aria-hidden="true" hidden>
+  <span class="typing-indicator__dot"></span>
+  <span class="typing-indicator__dot"></span>
+  <span class="typing-indicator__dot"></span>
+</div>
+
+<!-- AI 回覆的訊息氣泡以 streaming 狀態動態建立、appendToken()/complete() 逐步填入，
+     見下方「使用方式」；append 到任意容器（如對話容器）皆可 -->

--- a/layouts/_partials/ai/message-bubble/streaming.html
+++ b/layouts/_partials/ai/message-bubble/streaming.html
@@ -1,0 +1,20 @@
+<live-announcer></live-announcer>
+
+<div class="message-bubble-demo" data-mb-demo>
+  <div class="message-bubble-demo__stage" data-mb-stage></div>
+  <div class="typing-indicator" data-typing-indicator aria-hidden="true" hidden>
+    <span class="typing-indicator__dot"></span>
+    <span class="typing-indicator__dot"></span>
+    <span class="typing-indicator__dot"></span>
+  </div>
+  <div class="message-bubble-demo__actions">
+    <button type="button" class="button button-primary" data-mb-start>模擬 AI 回覆</button>
+  </div>
+
+  <!-- 可視化「已宣告內容」面板：僅供文件示範（沿用 live-announcer 示範面板），
+       展示分句播報與完成播報的時機。面板不掛任何 live 屬性。 -->
+  <p class="live-announcer-demo__title">已宣告內容</p>
+  <ol class="live-announcer-demo__log" data-demo-log>
+    <li class="live-announcer-demo__empty" data-demo-empty>尚未有任何宣告</li>
+  </ol>
+</div>

--- a/layouts/_partials/ai/typing-indicator/basic-source.html
+++ b/layouts/_partials/ai/typing-indicator/basic-source.html
@@ -1,0 +1,17 @@
+<live-announcer></live-announcer>
+
+<h2 id="chat-log-heading">與客服助理的對話</h2>
+<div
+  class="chat-container"
+  role="log"
+  aria-labelledby="chat-log-heading"
+  tabindex="0"
+  data-chat-container
+>
+  <message-bubble variant="user">請問今天客服時間到幾點？</message-bubble>
+  <div class="typing-indicator" data-typing-indicator aria-hidden="true" hidden>
+    <span class="typing-indicator__dot"></span>
+    <span class="typing-indicator__dot"></span>
+    <span class="typing-indicator__dot"></span>
+  </div>
+</div>

--- a/layouts/_partials/ai/typing-indicator/basic.html
+++ b/layouts/_partials/ai/typing-indicator/basic.html
@@ -1,0 +1,32 @@
+<live-announcer></live-announcer>
+
+<div class="typing-indicator-demo" data-ti-demo>
+  <h3 id="ti-demo-heading" class="typing-indicator-demo__heading">與客服助理的對話</h3>
+  <div
+    class="chat-container"
+    role="log"
+    aria-labelledby="ti-demo-heading"
+    tabindex="0"
+    data-chat-container
+  >
+    <message-bubble variant="user">請問今天客服時間到幾點？</message-bubble>
+    <div class="typing-indicator" data-typing-indicator aria-hidden="true" hidden>
+      <span class="typing-indicator__dot"></span>
+      <span class="typing-indicator__dot"></span>
+      <span class="typing-indicator__dot"></span>
+    </div>
+  </div>
+  <div class="typing-indicator-demo__actions">
+    <button type="button" class="button button-primary" data-ti-start>模擬等待回覆</button>
+  </div>
+
+  <!-- 純視覺狀態文字：只描述示範進度供人眼閱讀，不掛任何 live 屬性，
+       實際播報內容一律以下方「已宣告內容」面板為準，兩者不可混淆 -->
+  <p class="typing-indicator-demo__status" data-ti-status>尚未送出請求</p>
+
+  <!-- 可視化「已宣告內容」面板：僅供文件示範（沿用 live-announcer 示範面板機制） -->
+  <p class="live-announcer-demo__title">已宣告內容</p>
+  <ol class="live-announcer-demo__log" data-demo-log>
+    <li class="live-announcer-demo__empty" data-demo-empty>尚未有任何宣告</li>
+  </ol>
+</div>

--- a/static/js/components/chat-container.js
+++ b/static/js/components/chat-container.js
@@ -1,0 +1,125 @@
+/**
+ * chat-container.js — 對話容器（role="log"）互動邏輯
+ *
+ * 設計決策：
+ * - 屬性掛載：querySelectorAll('[data-chat-container]')，支援同頁多個執行個體
+ * - 容器語意由 HTML 提供（role="log" + aria-labelledby + tabindex="0"）；
+ *   JS 不建立任何 live region、不呼叫任何播報，整則訊息由 log 隱含
+ *   polite 播報；串流中、階段狀態、錯誤屬 live-announcer 的職責
+ * - 捲動策略：位置在底部 → 新訊息自動捲到底；上捲讀歷史 → 不捲動、
+ *   顯示「捲到最新訊息」按鈕；點擊按鈕 → 捲到底，焦點留在按鈕上
+ * - 按鈕的隱藏時機：聚焦期間不隱藏，blur 才隱藏。按鈕聚焦時直接隱藏
+ *   會造成焦點無聲消失（各瀏覽器行為不一致，不可依賴）；改為先標記
+ *   待隱藏，等使用者離開按鈕（blur）才真正隱藏
+ * - 新訊息永不搶焦點；視覺捲動與鍵盤焦點分開處理
+ * - 平滑捲動由 CSS scroll-behavior 控制（reduced-motion 由 SCSS 覆蓋為瞬時）
+ * - 對外 API：element.chatContainer.appendMessage(node)
+ *   只負責 append 與捲動，不產生節點內容（節點內容是 message-bubble 的職責）
+ */
+
+'use strict';
+
+// 「接近底部」判定閾值（px），可依實際使用情境調整。
+const NEAR_BOTTOM_THRESHOLD = 48;
+
+// 容器（tabindex="0"）聚焦時可觸發原生捲動的按鍵：視為使用者主動介入
+const SCROLL_KEYS = ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'];
+
+/**
+ * 捲動位置是否接近底部
+ * @param {HTMLElement} container
+ * @returns {boolean}
+ */
+function isNearBottom(container) {
+  return container.scrollHeight - container.scrollTop - container.clientHeight
+    <= NEAR_BOTTOM_THRESHOLD;
+}
+
+/**
+ * 初始化單一容器執行個體（每個執行個體各自維護狀態）
+ * @param {HTMLElement} container [data-chat-container] 元素
+ */
+function initChatContainer(container) {
+  // jump-latest 按鈕放在 log 元素外的同一父層，避免按鈕被當作 log 內容播報
+  const jumpButton = container.parentElement
+    ? container.parentElement.querySelector('[data-jump-latest]')
+    : null;
+
+  let nearBottom = isNearBottom(container);
+
+  // 平滑捲動進行中的暫時狀態：捲動尚未到底時 nearBottom 會短暫為 false，
+  // 以此旗標避免連續新增訊息時誤判為「使用者上捲中」
+  let autoScrolling = false;
+
+  // 按鈕聚焦時直接隱藏會造成焦點無聲消失（見檔頭說明），
+  // 改為標記待隱藏，等 blur 才實際隱藏。
+  let jumpButtonPendingHide = false;
+
+  function hideJumpButton() {
+    if (!jumpButton) return;
+    if (document.activeElement === jumpButton) {
+      jumpButtonPendingHide = true;
+    } else {
+      jumpButton.hidden = true;
+    }
+  }
+
+  if (jumpButton) {
+    jumpButton.addEventListener('blur', function () {
+      if (jumpButtonPendingHide) {
+        jumpButton.hidden = true;
+        jumpButtonPendingHide = false;
+      }
+    });
+  }
+
+  function scrollToBottom() {
+    autoScrolling = true;
+    container.scrollTo({ top: container.scrollHeight });
+    hideJumpButton();
+  }
+
+  container.addEventListener('scroll', function () {
+    nearBottom = isNearBottom(container);
+    if (nearBottom) {
+      autoScrolling = false;
+      hideJumpButton();
+    }
+  });
+
+  // 使用者主動介入（滾輪／觸控／鍵盤捲動／拖曳捲軸）即取消自動捲到底，尊重使用者的閱讀位置
+  ['wheel', 'touchstart', 'mousedown'].forEach(function (type) {
+    container.addEventListener(type, function () {
+      autoScrolling = false;
+    }, { passive: true });
+  });
+
+  container.addEventListener('keydown', function (event) {
+    if (SCROLL_KEYS.includes(event.key)) autoScrolling = false;
+  });
+
+  if (jumpButton) {
+    jumpButton.addEventListener('click', function () {
+      // 捲到底；焦點留在按鈕上，按鈕要等 blur 才隱藏（見檔頭說明）
+      scrollToBottom();
+    });
+  }
+
+  container.chatContainer = {
+    /**
+     * 將訊息節點加入 log 末端並依捲動策略處理捲動
+     * @param {Node} node
+     */
+    appendMessage: function (node) {
+      container.append(node);
+      if (nearBottom || autoScrolling) {
+        scrollToBottom();
+      } else if (jumpButton) {
+        jumpButtonPendingHide = false;
+        jumpButton.hidden = false;
+      }
+    },
+  };
+}
+
+document.querySelectorAll('[data-chat-container]').forEach(initChatContainer);

--- a/static/js/components/live-announcer.js
+++ b/static/js/components/live-announcer.js
@@ -1,0 +1,146 @@
+/**
+ * live-announcer.js — 即時宣告元件（<live-announcer> Custom Element）
+ *
+ * 設計決策：
+ * - 對外 API 為 instance method：announce(message) / alert(message)，
+ *   呼叫端以 document.querySelector('live-announcer') 取得執行個體後呼叫
+ * - light DOM（不用 Shadow DOM），全站樣式與 .visually-hidden 照常生效
+ * - 內部固定兩個獨立 region，頁面載入（connectedCallback）即建立：
+ *   polite：aria-live="polite" + aria-atomic="true"
+ *   assertive：role="alert"
+ *   不動態切換 aria-live 值；region 必須先存在於 DOM 才會被 AT 播報
+ * - 寫入慣例：一律 textContent（防 XSS）；清空 → 100ms → 填入，
+ *   確保相同訊息可重複觸發宣告；上一則訊息至少保留 1000ms 才被清空
+ * - 每次實際寫入時 dispatch CustomEvent('live-announcer:announced')，
+ *   detail.message 為呼叫時的原文（不含下述交替附加的 NBSP）；供文件
+ *   示範面板等外部觀察者使用，亦是 message-bubble 等呼叫端確認訊息
+ *   是否已實際送達的訊號
+ * - 主流螢幕閱讀器（NVDA、VoiceOver）對 live region 連續相同文字會在
+ *   語音層去除重複，一般半形空格也會被正規化掉而失效；改為交替附加
+ *   一個 U+00A0（NBSP）可繞過此限制，是 WordPress 核心 wp.a11y.speak
+ *   驗證過的手法。移除此機制將使螢幕閱讀器不再重播連續相同訊息；
+ *   本機制無正式規格保證，需以人工聽測驗證
+ * - 不做佇列管理、不做分句斷句（斷句為呼叫端職責）、無任何視覺輸出
+ * - data-live-region 屬性保留為純 DOM fallback：極端無法取得執行個體的環境
+ *   可直接對該節點寫入 textContent（最後手段）
+ */
+
+'use strict';
+
+// 清空 → 填入的間隔，讓 AT 感知「空 → 有」的變化，相同訊息才會重新宣告
+const CLEAR_TO_SET_DELAY = 100;
+
+// 上一則訊息至少保留的毫秒數，讓 AT 有時間讀完
+const MIN_MESSAGE_HOLD = 1000;
+
+class LiveAnnouncer extends HTMLElement {
+  connectedCallback() {
+    // 全站單例原則：偵測到多個執行個體時提醒，但不阻斷（文件頁示範可能需要）
+    if (document.querySelectorAll('live-announcer').length > 1) {
+      console.warn('<live-announcer> 應全站僅掛載一個，偵測到多個執行個體。');
+    }
+
+    if (!this._regions) {
+      this._regions = {
+        polite: {
+          el: this._createRegion('polite'),
+          clearTimer: null,
+          setTimer: null,
+          lastSetAt: 0,
+          appendNbsp: false,
+        },
+        assertive: {
+          el: this._createRegion('assertive'),
+          clearTimer: null,
+          setTimer: null,
+          lastSetAt: 0,
+          appendNbsp: false,
+        },
+      };
+    }
+  }
+
+  /**
+   * 一般提示（polite）：等 AT 讀完手邊內容才播
+   * @param {string} message 純文字訊息
+   */
+  announce(message) {
+    this._write('polite', message);
+  }
+
+  /**
+   * 必要中斷（assertive）：僅限錯誤、逾時等必須立即通知的情況
+   * @param {string} message 純文字訊息
+   */
+  alert(message) {
+    this._write('assertive', message);
+  }
+
+  /**
+   * 建立（或沿用既有的）live region 節點
+   * @param {'polite'|'assertive'} level
+   * @returns {HTMLElement}
+   */
+  _createRegion(level) {
+    let region = this.querySelector('[data-live-region="' + level + '"]');
+    if (region) return region;
+
+    region = document.createElement('div');
+    region.className = 'live-announcer__region visually-hidden';
+    region.setAttribute('data-live-region', level);
+
+    if (level === 'assertive') {
+      region.setAttribute('role', 'alert');
+    } else {
+      region.setAttribute('aria-live', 'polite');
+      region.setAttribute('aria-atomic', 'true');
+    }
+
+    this.append(region);
+    return region;
+  }
+
+  /**
+   * 寫入流程（兩個等級共用）：
+   * 等上一則保留滿 1000ms → 清空 → 100ms → 填入新訊息。
+   * 短時間連續呼叫採「後者覆蓋前者」，不做佇列。
+   * @param {'polite'|'assertive'} level
+   * @param {string} message
+   */
+  _write(level, message) {
+    if (!this._regions) return; // 尚未掛載於 DOM 時靜默略過
+
+    const text = typeof message === 'string' ? message : String(message);
+    const state = this._regions[level];
+
+    clearTimeout(state.clearTimer);
+    clearTimeout(state.setTimer);
+
+    const elapsed = Date.now() - state.lastSetAt;
+    const holdDelay = Math.max(0, MIN_MESSAGE_HOLD - elapsed);
+
+    state.clearTimer = setTimeout(() => {
+      state.el.textContent = '';
+      state.setTimer = setTimeout(() => {
+        // 交替附加 NBSP（U+00A0）防主流 AT 語音層對連續相同文字去除
+        // 重複（見檔頭說明；一般半形空格會被去除重複比對正規化掉，
+        // NBSP 不會）。dispatch 的 detail.message 維持原文，送達確認
+        // 等呼叫端邏輯不受影響。第一次寫入不加後綴，維持與呼叫原文
+        // 完全相等（單次播報是最常見情境，交替只在連續相同文字時才
+        // 有意義）
+        const useNbsp = state.appendNbsp;
+        state.appendNbsp = !state.appendNbsp;
+        state.el.textContent = useNbsp ? text + '\u00A0' : text;
+        state.lastSetAt = Date.now();
+        this.dispatchEvent(new CustomEvent('live-announcer:announced', {
+          bubbles: true,
+          detail: { level: level, message: text },
+        }));
+      }, CLEAR_TO_SET_DELAY);
+    }, holdDelay);
+  }
+}
+
+window.customElements.define('live-announcer', LiveAnnouncer);
+
+export default LiveAnnouncer;

--- a/static/js/components/message-bubble.js
+++ b/static/js/components/message-bubble.js
@@ -1,0 +1,428 @@
+/**
+ * message-bubble.js — 訊息氣泡元件（<message-bubble> Custom Element）
+ *
+ * 設計決策：
+ * - Custom Element、light DOM；動態 createElement 插入即自動掛上行為
+ * - 內層為語意化 <article>，以 aria-labelledby 指向可見角色標題；
+ *   Custom Element 標籤本身不承載 ARIA
+ * - 串流播報（開始輸入、分句進度、完成、停止、錯誤）：
+ *   串流中正文掛 aria-hidden="true"（aria-busy 於 NVDA/VoiceOver 實測
+ *   不受支援，僅 JAWS 部分支援）、操作列 hidden；分句（。！？；換行）
+ *   + 距上次播報 ≥1100ms 才呼叫 <live-announcer>.announce()，未滿間隔
+ *   的完整句進待播緩衝由 timer 送出
+ * - 串流終止的判定與後端無關：對外只有 appendToken()/complete()/abort()/error()
+ * - 操作列＝複製／重新生成／讚／倒讚；roving tabindex 沿用 toolbar.js
+ * - 收尾（complete/abort）與殘句播報合併為同一次 announce
+ * - 送達確認（_pendingAnnounce／_dispatchAnnounce）：送下一批前若前一批
+ *   尚未確認送達，一律將其文字併入本批重送，不另外呼叫兩次。此依賴
+ *   live-announcer._write「後者取消前者未寫入 timer」的既定行為，
+ *   修改該行為需同步回改本檔
+ * - error() 為終結態：放棄重送任何尚未送達的分句批，改以 announce('')
+ *   截斷 polite 頻道（live-announcer 無獨立取消 API，這是在既有介面
+ *   內達成「取消」的手段）
+ * - 無 JS：伺服器渲染的靜態結構可讀；操作列（含讚/倒讚）維持 hidden
+ */
+
+'use strict';
+
+import { initToolbar } from './toolbar.js';
+
+// 分句播報的最小間隔（ms）。必須 > live-announcer 保留期（1000ms），
+// 否則前一句尚未送達即被下一句覆蓋而無聲丟句
+const ANNOUNCE_MIN_INTERVAL = 1100;
+
+// 句末標點：。！？；與換行
+const SENTENCE_PATTERN = /[^。！？；\n]*[。！？；\n]+/g;
+
+let roleIdCounter = 0;
+let warnedNoAnnouncer = false;
+
+const bubbleTemplate = document.createElement('template');
+bubbleTemplate.innerHTML = `
+  <article class="message-bubble__inner">
+    <p class="message-bubble__role"></p>
+    <div class="message-bubble__slot-pre" hidden></div>
+    <div class="message-bubble__body"></div>
+    <p class="message-bubble__error" hidden></p>
+    <div class="toolbar message-bubble__toolbar" role="toolbar" aria-label="訊息操作" hidden>
+      <button type="button" class="toolbar__button" data-action="copy" tabindex="0">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+        </svg>
+        <span class="visually-hidden">複製</span>
+      </button>
+      <button type="button" class="toolbar__button" data-action="regenerate" tabindex="-1">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <polyline points="23 4 23 10 17 10"/>
+          <polyline points="1 20 1 14 7 14"/>
+          <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>
+        </svg>
+        <span class="visually-hidden">重新生成</span>
+      </button>
+      <button type="button" class="toolbar__button toolbar__button--toggle" data-action="like" aria-pressed="false" tabindex="-1">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
+        </svg>
+        <span class="visually-hidden">讚</span>
+      </button>
+      <button type="button" class="toolbar__button toolbar__button--toggle" data-action="dislike" aria-pressed="false" tabindex="-1">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"/>
+        </svg>
+        <span class="visually-hidden">倒讚</span>
+      </button>
+    </div>
+  </article>
+`;
+
+class MessageBubble extends HTMLElement {
+  connectedCallback() {
+    if (!this._initialized) {
+      this._initialized = true;
+
+      this._variant = this.getAttribute('variant') === 'user' ? 'user' : 'ai';
+
+      // progressive：允許伺服器端已渲染完整結構，JS 只掛行為
+      let inner = this.querySelector('.message-bubble__inner');
+      if (!inner) inner = this._buildStructure();
+
+      this._body = inner.querySelector('.message-bubble__body');
+      this._errorEl = inner.querySelector('.message-bubble__error');
+      this._toolbar = inner.querySelector('.message-bubble__toolbar');
+
+      // data-role-label 覆寫角色標題文字（動態／靜態建構路徑皆適用）；
+      // 未指定時沿用預設（動態路徑為「你」／「客服助理」，靜態路徑沿用
+      // 伺服器渲染好的文字）
+      const roleLabel = this.getAttribute('data-role-label');
+      if (roleLabel) {
+        const role = inner.querySelector('.message-bubble__role');
+        if (role) role.textContent = roleLabel;
+      }
+
+      this._sentenceBuffer = '';
+      this._pendingSentences = [];
+      this._lastAnnounceAt = 0;
+      this._debounceTimer = null;
+      this._ended = false;
+
+      // 本元件自己呼叫的最近一批 polite 訊息，尚未收到 'live-announcer:announced'
+      // 確認送達前保持非 null；見檔頭「送達確認」說明
+      this._pendingAnnounce = null;
+
+      if (this.hasAttribute('streaming')) {
+        this._enterStreaming();
+      } else if (this._toolbar) {
+        // JS 啟用後才顯示操作列（無 JS 時讚/倒讚等維持隱藏）
+        this._toolbar.hidden = false;
+      }
+
+      if (this._toolbar) {
+        // 不論結構來自伺服器渲染或動態建立都主動初始化：initToolbar 本身
+        // 已冪等（見 toolbar.js），若靜態渲染的 toolbar 已被頁面載入時的
+        // 自動初始化處理過，這裡會是無害的重複呼叫
+        initToolbar(this._toolbar);
+        this._wireToolbarActions();
+      }
+    }
+
+    // live-announcer 送達確認監聽：結構只建立一次，但監聽綁定跟隨標準
+    // Custom Element 生命週期，每次 connected 重新綁定、disconnected 解綁。
+    // 串流中把氣泡搬到另一個父節點會先觸發 disconnectedCallback 再觸發
+    // connectedCallback，若監聽只在首次 connected 綁定一次，重掛載後就
+    // 收不到 'live-announcer:announced'，送達確認鏈永久失效
+    this._onAnnounced = (event) => {
+      const detail = event.detail;
+      if (detail && detail.level === 'polite' && detail.message === this._pendingAnnounce) {
+        this._pendingAnnounce = null;
+      }
+    };
+    document.addEventListener('live-announcer:announced', this._onAnnounced);
+  }
+
+  disconnectedCallback() {
+    if (this._onAnnounced) document.removeEventListener('live-announcer:announced', this._onAnnounced);
+    // 待播 timer 一併清除，避免元件已從文件移除後才觸發 flush；
+    // _pendingSentences 緩衝本身保留不清空，重掛載後由後續的
+    // appendToken()／complete()／abort() 接手送出
+    clearTimeout(this._debounceTimer);
+    this._debounceTimer = null;
+  }
+
+  // ── 對外方法（串流抽象介面，後端無關）─────────────────
+
+  /**
+   * 追加一段串流文字
+   * @param {string} text
+   */
+  appendToken(text) {
+    if (this._ended || !this._body) return;
+    const str = typeof text === 'string' ? text : String(text);
+    if (!this.hasAttribute('streaming')) this._enterStreaming();
+
+    this._body.append(document.createTextNode(str));
+
+    this._sentenceBuffer += str;
+    this._extractSentences();
+    if (this._pendingSentences.length) this._scheduleFlush();
+  }
+
+  /** 回覆完成；結語文字可用 data-complete-message 覆寫 */
+  complete() {
+    this._finishStreaming(this.getAttribute('data-complete-message') || '回覆完成');
+  }
+
+  /**
+   * 停止生成：保留已生成部分。停止按鈕由 composer 提供；
+   * 結語文字可用 data-abort-message 覆寫
+   */
+  abort() {
+    this._finishStreaming(this.getAttribute('data-abort-message') || '已停止產生回覆');
+  }
+
+  /**
+   * 錯誤：assertive 播報 + 氣泡內可見錯誤文字
+   * @param {string} message
+   */
+  error(message) {
+    if (!this._body) return;
+    const msg = typeof message === 'string' ? message : String(message);
+
+    clearTimeout(this._debounceTimer);
+    this._debounceTimer = null;
+    this._pendingSentences = [];
+    this._sentenceBuffer = '';
+
+    // 終結態：放棄重送任何尚未確認送達的分句批，改截斷 polite 頻道，
+    // 避免它在 error 之後才播出（見檔頭「error() 為終結態」說明）
+    if (this._pendingAnnounce !== null) {
+      this._pendingAnnounce = null;
+      this._announce('');
+    }
+
+    if (this._errorEl) {
+      // 錯誤以文字標示，不只靠顏色
+      this._errorEl.textContent = '錯誤：' + msg;
+      this._errorEl.hidden = false;
+    }
+    this._alert(msg);
+
+    this._body.removeAttribute('aria-hidden');
+    if (this._toolbar) this._toolbar.hidden = false; // 保留重新生成的入口
+    this.removeAttribute('streaming');
+    this._ended = true;
+  }
+
+  // ── 串流狀態與分句播報 ────────────────────────────────
+
+  _enterStreaming() {
+    if (!this.hasAttribute('streaming')) this.setAttribute('streaming', '');
+    this._body.setAttribute('aria-hidden', 'true');
+    if (this._toolbar) this._toolbar.hidden = true;
+  }
+
+  /** 從緩衝取出完整句（。！？；換行結尾），移入待播清單 */
+  _extractSentences() {
+    let consumed = 0;
+    let match;
+    SENTENCE_PATTERN.lastIndex = 0;
+    while ((match = SENTENCE_PATTERN.exec(this._sentenceBuffer)) !== null) {
+      const sentence = match[0].trim();
+      if (sentence) this._pendingSentences.push(sentence);
+      consumed = SENTENCE_PATTERN.lastIndex;
+    }
+    if (consumed > 0) this._sentenceBuffer = this._sentenceBuffer.slice(consumed);
+  }
+
+  /** 距上次播報 ≥1100ms 立即送出；未滿間隔由 timer 補送 */
+  _scheduleFlush() {
+    const elapsed = Date.now() - this._lastAnnounceAt;
+    if (elapsed >= ANNOUNCE_MIN_INTERVAL) {
+      this._flushSentences();
+      return;
+    }
+    if (!this._debounceTimer) {
+      this._debounceTimer = setTimeout(() => {
+        this._debounceTimer = null;
+        this._flushSentences();
+      }, ANNOUNCE_MIN_INTERVAL - elapsed);
+    }
+  }
+
+  _flushSentences() {
+    if (!this._pendingSentences.length) return;
+    const message = this._pendingSentences.join('');
+    this._pendingSentences = [];
+    this._lastAnnounceAt = Date.now();
+    this._dispatchAnnounce(message);
+  }
+
+  /**
+   * complete/abort 共用收尾：殘句與結語合併為同一次播報，移除正文
+   * aria-hidden、顯示操作列、移除 streaming 屬性；不移動焦點
+   * @param {string} closingMessage
+   */
+  _finishStreaming(closingMessage) {
+    if (!this._body || this._ended) return;
+
+    clearTimeout(this._debounceTimer);
+    this._debounceTimer = null;
+
+    const leftover = (this._pendingSentences.join('') + this._sentenceBuffer).trim();
+    this._pendingSentences = [];
+    this._sentenceBuffer = '';
+
+    let message = closingMessage;
+    if (leftover) {
+      message = /[。！？；.!?;]$/.test(leftover)
+        ? leftover + closingMessage
+        : leftover + '。' + closingMessage;
+    }
+    // 立即送出：不再用「呼叫時刻 + 節流下限」來估算前批送達時間，
+    // _dispatchAnnounce 會在前批尚未確認送達時把它併入本批重送，
+    // 結構性保證收尾不會覆蓋尚未播出的內容（見檔頭「送達確認」說明）
+    this._dispatchAnnounce(message);
+
+    this._body.removeAttribute('aria-hidden');
+    if (this._toolbar) this._toolbar.hidden = false;
+    this.removeAttribute('streaming');
+    this._ended = true;
+  }
+
+  // ── live-announcer 橋接 ──────────────────────────────
+
+  _getAnnouncer() {
+    const announcer = document.querySelector('live-announcer');
+    if (!announcer || typeof announcer.announce !== 'function') {
+      if (!warnedNoAnnouncer) {
+        console.warn('message-bubble：頁面上找不到可用的 <live-announcer>，播報將被略過。');
+        warnedNoAnnouncer = true;
+      }
+      return null;
+    }
+    return announcer;
+  }
+
+  /**
+   * 送出 polite 播報；若本元件上一批呼叫的訊息尚未收到送達確認
+   * （'live-announcer:announced'），把它的全文併入本批重送而非另外
+   * 呼叫一次。這刻意依賴 live-announcer._write 對同通道連續呼叫
+   * 「後者取消前者尚未寫入 region 的 timer」的既定行為：前批全文已
+   * 併入本批，取代它不會漏播，也不會雙播。分句 flush 與收尾都經由
+   * 此函式，消除兩者之間「呼叫時刻節流 ≈ 實際寫入時刻」的邊際誤差，
+   * 避免句子被靜默取消而遺失。切勿把 _pendingAnnounce 追蹤
+   * 當成多餘防禦移除
+   * @param {string} message
+   */
+  _dispatchAnnounce(message) {
+    const combined = this._pendingAnnounce !== null
+      ? this._pendingAnnounce + message
+      : message;
+    this._announce(combined);
+  }
+
+  _announce(message) {
+    const announcer = this._getAnnouncer();
+    if (!announcer) return;
+    this._pendingAnnounce = message;
+    announcer.announce(message);
+  }
+
+  _alert(message) {
+    const announcer = this._getAnnouncer();
+    if (announcer) announcer.alert(message);
+  }
+
+  // ── 結構建立與操作列 ─────────────────────────────────
+
+  /** 動態插入（無伺服器渲染結構）時建立內部結構；既有子節點移入正文 */
+  _buildStructure() {
+    const existingChildren = Array.from(this.childNodes);
+
+    const fragment = bubbleTemplate.content.cloneNode(true);
+    const inner = fragment.querySelector('.message-bubble__inner');
+    const role = fragment.querySelector('.message-bubble__role');
+    const body = fragment.querySelector('.message-bubble__body');
+
+    inner.classList.add(this._variant === 'user' ? 'message-bubble__inner--user' : 'message-bubble__inner--ai');
+    role.id = 'message-bubble-role-' + (roleIdCounter += 1);
+    role.textContent = this._variant === 'user' ? '你' : '客服助理';
+    inner.setAttribute('aria-labelledby', role.id);
+
+    if (this._variant === 'user') {
+      fragment.querySelector('.message-bubble__toolbar').remove();
+      fragment.querySelector('.message-bubble__error').remove();
+    }
+
+    existingChildren.forEach((node) => body.append(node));
+    this.append(fragment);
+    return inner;
+  }
+
+  _wireToolbarActions() {
+    const copyBtn = this._toolbar.querySelector('[data-action="copy"]');
+    const regenBtn = this._toolbar.querySelector('[data-action="regenerate"]');
+    const likeBtn = this._toolbar.querySelector('[data-action="like"]');
+    const dislikeBtn = this._toolbar.querySelector('[data-action="dislike"]');
+
+    if (copyBtn) {
+      copyBtn.addEventListener('click', () => this._copyBody());
+    }
+
+    if (regenBtn) {
+      regenBtn.addEventListener('click', () => {
+        // 元件本體不重送請求，由外部（composer／後端串接）接手
+        this.dispatchEvent(new CustomEvent('message-bubble:regenerate', { bubbles: true }));
+      });
+    }
+
+    // 讚/倒讚三態互斥：toolbar.js 的 click listener（先註冊）切換完
+    // aria-pressed 後，這裡強制另一顆為 false
+    if (likeBtn && dislikeBtn) {
+      [likeBtn, dislikeBtn].forEach((btn, index, pair) => {
+        btn.addEventListener('click', () => {
+          if (btn.getAttribute('aria-pressed') === 'true') {
+            pair[1 - index].setAttribute('aria-pressed', 'false');
+          }
+          const value = likeBtn.getAttribute('aria-pressed') === 'true'
+            ? 'up'
+            : dislikeBtn.getAttribute('aria-pressed') === 'true' ? 'down' : null;
+          this.dispatchEvent(new CustomEvent('message-bubble:feedback', {
+            bubbles: true,
+            detail: { value: value },
+          }));
+        });
+      });
+    }
+  }
+
+  _copyBody() {
+    const text = this._body ? this._body.textContent : '';
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(
+        () => this._dispatchAnnounce('已複製'),
+        () => this._copyFallback()
+      );
+    } else {
+      this._copyFallback();
+    }
+  }
+
+  /** 剪貼簿 API 不可用時的備援機制：選取正文文字並提示手動複製 */
+  _copyFallback() {
+    try {
+      const range = document.createRange();
+      range.selectNodeContents(this._body);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      this._dispatchAnnounce('無法自動複製，已選取訊息文字，請手動複製');
+    } catch {
+      this._dispatchAnnounce('無法複製');
+    }
+  }
+}
+
+window.customElements.define('message-bubble', MessageBubble);
+
+export default MessageBubble;

--- a/static/js/components/toolbar.js
+++ b/static/js/components/toolbar.js
@@ -52,6 +52,11 @@ function updateRovingTabindex(items, activeIndex) {
  * @param {HTMLElement} toolbarEl
  */
 function initToolbar(toolbarEl) {
+  // 冪等保護：同一節點可能同時被頁面載入時的自動初始化與消費端元件
+  // （如 message-bubble）主動呼叫覆蓋到，重複初始化會疊加事件監聽
+  if (toolbarEl.dataset.toolbarInitialized) return;
+  toolbarEl.dataset.toolbarInitialized = 'true';
+
   var items = getToolbarItems(toolbarEl);
 
   if (items.length === 0) return;
@@ -227,3 +232,6 @@ function initToolbar(toolbarEl) {
 document.querySelectorAll('[role="toolbar"]').forEach(function (toolbarEl) {
   initToolbar(toolbarEl);
 });
+
+// 供動態插入 toolbar 的元件（如 message-bubble）主動初始化
+export { initToolbar };

--- a/static/js/components/typing-indicator.js
+++ b/static/js/components/typing-indicator.js
@@ -1,0 +1,120 @@
+/**
+ * typing-indicator.js — 輸入中提示互動邏輯
+ *
+ * 設計決策：
+ * - 屬性掛載：querySelectorAll('[data-typing-indicator]')，對外 API 比照
+ *   chat-container 慣例掛 element.typingIndicator = { show(), hide() }
+ * - 動畫節點整體 aria-hidden="true" 常駐、永不移除；狀態完全交由
+ *   live-announcer 播報一次，節點本身不承載任何輔助科技可讀的文字
+ * - 防閃爍只靠延遲出現（等待期短於此值即被 hide() 取消則不顯示、不
+ *   宣告）；不設最短顯示時間，它會使三點動畫與已抵達的串流文字並存重疊，誤導
+ *   使用者；hide() 一律立即移除視覺，防閃爍完全由延遲出現承擔
+ * - 送達確認：show() 的宣告監聽一次 live-announcer:announced（比對訊息
+ *   全文），確認實際寫入 region 後才 dispatch typing-indicator:announced。
+ *   多個播報來源共用同一個 polite 頻道時，時間相近的呼叫，後者會覆蓋
+ *   前者，串接方以此事件為「可以開始送出回覆內容」的訊號，避免
+ *   「正在輸入」被後續播報覆蓋
+ * - show() 冪等：等待中或已顯示時重複呼叫不重啟計時、不重複宣告
+ * - hide() 在延遲等待期間呼叫：計時器直接取消，什麼都不發生、不宣告；
+ *   已顯示時呼叫：立即隱藏，不宣告任何結束訊息。隱藏後若再次 show()，
+ *   視為新的一輪等待（例如使用者又送出一則新訊息），重新走一次完整的
+ *   延遲出現流程並重新宣告
+ * - 找不到 <live-announcer>：console.warn、視覺照常（與 message-bubble
+ *   同慣例）
+ */
+
+'use strict';
+
+// 等待期短於此值即被 hide() 取消則不顯示、不宣告，避免極快回覆時的閃爍
+const SHOW_DELAY = 300;
+
+let warnedNoAnnouncer = false;
+
+function getAnnouncer() {
+  const announcer = document.querySelector('live-announcer');
+  if (!announcer || typeof announcer.announce !== 'function') {
+    if (!warnedNoAnnouncer) {
+      console.warn('typing-indicator：頁面上找不到可用的 <live-announcer>，播報將被略過。');
+      warnedNoAnnouncer = true;
+    }
+    return null;
+  }
+  return announcer;
+}
+
+/**
+ * 初始化單一節點執行個體（每個執行個體各自維護狀態）
+ * @param {HTMLElement} el [data-typing-indicator] 元素
+ */
+function initTypingIndicator(el) {
+  const text = el.getAttribute('data-typing-text') || 'AI 正在輸入';
+
+  // 是否已請求顯示（涵蓋等待中與已顯示），用於 show() 的冪等判斷
+  let active = false;
+  let delayTimer = null; // 延遲出現計時
+
+  // 上一輪 announce() 尚未觸發的送達監聽參照；hide() 與新一輪 announce()
+  // 都會先把它移除，避免前一輪的送達確認遲到才觸發，在 hide() 之後或
+  // 新一輪播報開始後才 dispatch 一個屬於舊一輪的 typing-indicator:announced
+  let pendingOnAnnounced = null;
+
+  function clearPendingAnnounced() {
+    if (pendingOnAnnounced) {
+      document.removeEventListener('live-announcer:announced', pendingOnAnnounced);
+      pendingOnAnnounced = null;
+    }
+  }
+
+  function announce() {
+    const announcer = getAnnouncer();
+    if (!announcer) return;
+
+    clearPendingAnnounced();
+
+    const onAnnounced = function (event) {
+      const detail = event.detail;
+      if (detail && detail.level === 'polite' && detail.message === text) {
+        clearPendingAnnounced();
+        el.dispatchEvent(new CustomEvent('typing-indicator:announced', { bubbles: true }));
+      }
+    };
+    pendingOnAnnounced = onAnnounced;
+    document.addEventListener('live-announcer:announced', onAnnounced);
+    announcer.announce(text);
+  }
+
+  el.typingIndicator = {
+    show: function () {
+      if (active) return; // 冪等：等待中或已顯示皆不重啟、不重複宣告
+      active = true;
+
+      delayTimer = setTimeout(function () {
+        delayTimer = null;
+        // 節點在延遲出現期間被移出文件（例如訊息列表整段重繪）：不顯示、
+        // 不宣告；同時重置 active，否則節點若原地重插，show() 的冪等判斷
+        // 會誤判為「已在等待/顯示中」而永久鎖死，之後 show() 無法再觸發
+        if (!el.isConnected) {
+          active = false;
+          return;
+        }
+        el.hidden = false;
+        announce();
+      }, SHOW_DELAY);
+    },
+
+    hide: function () {
+      active = false;
+      clearPendingAnnounced(); // 前一輪送達確認一併失效，hide() 之後不再 dispatch
+
+      if (delayTimer) {
+        clearTimeout(delayTimer);
+        delayTimer = null;
+        return; // 一次都沒顯示過：什麼都不發生，不宣告
+      }
+
+      el.hidden = true; // 立即移除視覺，不設最短顯示時間
+    },
+  };
+}
+
+document.querySelectorAll('[data-typing-indicator]').forEach(initTypingIndicator);


### PR DESCRIPTION
## 背景與目的

本 PR 建立 AI 對話介面的第一批共用元件，提供訊息呈現、串流回覆、等待狀態、螢幕閱讀器播報及對話捲動等基礎能力。

元件不綁定特定後端或 AI API，呼叫端只需將後端事件轉換為元件提供的方法，即可組合成完整的對話流程。


## 修改摘要

| 元件 | 本次實作內容 |
| --- | --- |
| Live Announcer | 提供 polite／assertive 兩種即時宣告，處理相同訊息重複播報及訊息保留時間 |
| Chat Container | 提供 `role="log"` 對話容器、自動捲到底及「捲到最新訊息」操作 |
| Message Bubble | 支援使用者／AI 訊息、串流文字、完成／停止／錯誤狀態及訊息操作列 |
| Typing Indicator | 提供延遲顯示的等待動畫與「AI 正在輸入」播報 |
| 文件與 Demo | 新增元件說明頁、互動範例、原始碼範例及相關 SCSS |

## 主要實作內容

### 1. Live Announcer

新增 `<live-announcer>` Custom Element，作為各 AI 元件共用的播報基礎。

- 分別維護 polite 與 assertive live region。
- 前一則訊息至少保留 1 秒，降低播報被後續訊息覆蓋的風險。
- 為避免螢幕閱讀器略過連續出現的相同訊息，元件會交替加入不影響畫面顯示的不換行空白字元（NBSP），讓相同內容仍可再次播報。
 例如：使用者在連線中斷時送出訊息，系統會通知「連線已中斷」；稍後再次嘗試送出訊息但連線仍未恢復時，相同通知也需要再次播報。
- 實際寫入 live region 後觸發 `live-announcer:announced` 事件，供其他元件確認訊息已送達。
- 全站原則上僅需掛載一個執行個體。

### 2. Chat Container

新增對話容器的捲動管理邏輯。

- 對話位於底部時，新訊息會自動捲到最新位置。
- 使用者正在閱讀歷史訊息時，不會強制改變捲動位置。
- 有新訊息時顯示「捲到最新訊息」按鈕。
- 使用者透過滾輪、觸控、捲軸或鍵盤捲動時，會取消自動捲動狀態。
- 按鈕取得焦點後不會立即隱藏，避免鍵盤焦點無預警消失。
- 對外提供 `container.chatContainer.appendMessage(node)`。

### 3. Message Bubble

新增 `<message-bubble>` Custom Element，支援靜態訊息與串流回覆。

對外 API：

```js
bubble.appendToken(text);
bubble.complete();
bubble.abort();
bubble.error(message);
```

主要行為：

- 支援使用者與 AI 兩種訊息樣式。
- 使用可見角色標題，並以 `aria-labelledby` 將訊息與角色標題關聯，讓螢幕閱讀器能辨識訊息來源。
- 串流期間將正文設為 `aria-hidden="true"`，改由 Live Announcer 分句播報。
- 依句末標點切分內容，並以至少 1,100 ms 的間隔節流播報。
- `complete()` 與 `abort()` 會合併尚未播報的殘句及結語，避免遺漏內容。
- `error()` 同時顯示可見錯誤文字，並透過 assertive live region 播報。
- AI 訊息完成後顯示複製、重新生成、讚及倒讚操作。
- 重新生成及回饋操作分別透過 `message-bubble:regenerate`、`message-bubble:feedback` 事件通知外部。

### 4. Typing Indicator

新增等待回覆時使用的輸入中提示。

- `show()` 延遲 300 ms 顯示，避免極短回應造成畫面閃爍。
- `hide()` 立即隱藏，避免等待動畫與已抵達的回覆同時出現。
- 重複呼叫 `show()` 不會重新計時或重複播報。
- 「AI 正在輸入」實際送達 Live Announcer 後，觸發 `typing-indicator:announced`。
- `prefers-reduced-motion: reduce` 下改用較輕微的透明度動畫。

### 5. Toolbar 整合

為支援動態建立的 Message Bubble，本次亦調整既有 `toolbar.js`：

- 匯出 `initToolbar()`，讓動態插入的操作列可主動初始化。
- 加入重複初始化檢查，避免同一個 Toolbar 重複綁定事件。
- 既有頁面載入時的自動初始化行為維持不變。

## 建議 Review 順序

本次元件之間存在播報與事件相依關係，建議依下列順序閱讀：

1. `static/js/components/live-announcer.js`
   - 先確認 live region、訊息保留及送達事件的設計。
2. `static/js/components/message-bubble.js`
   - 本次主要邏輯集中處，包含串流分句、節流、完成及錯誤處理。
3. `static/js/components/typing-indicator.js`
   - 確認等待狀態如何與 Live Announcer 協作。
4. `static/js/components/chat-container.js`
   - 確認捲動狀態及鍵盤操作。
5. `static/js/components/toolbar.js`
   - 本次僅新增匯出介面及重複初始化檢查。
6. `content/components/ai/`、`layouts/_partials/ai/`、`assets/js/demo/`
   - 最後確認使用說明、範例及實際元件行為是否一致。