### PR TITLE
ci: 強化 GitHub Actions workflows 安全性(修補 pwn-request 與 secrets 外洩風險)

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -5,12 +5,15 @@ on:
 
   # Triggers the workflow when pull request is opened or updated
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
+
+# Cancel an in-progress run for the same PR/branch when a new commit arrives
+concurrency:
+  group: lighthouse-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lighthouseci:
-    # Run this job if labeled with 'ci-lighthouse'
-    if: ${{ github.event.label.name == 'ci-lighthouse' }}
     runs-on: ubuntu-latest
     steps:
       #ref: https://github.com/actions/starter-workflows/tree/main/pages

--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -11,6 +11,9 @@ on:
       - 'content/**'
       - 'layouts/**'
       - 'static/js/**'
+      - '.github/workflows/lhci.yml'
+      - '.lighthouserc.json'
+      - 'hugo.toml'
 
 # Cancel an in-progress run for the same PR/branch when a new commit arrives
 concurrency:

--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -6,6 +6,11 @@ on:
   # Triggers the workflow when pull request is opened or updated
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'assets/**'
+      - 'content/**'
+      - 'layouts/**'
+      - 'static/js/**'
 
 # Cancel an in-progress run for the same PR/branch when a new commit arrives
 concurrency:
@@ -20,8 +25,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # Fall back to the triggering ref/repo when not run from a pull request
+          # (e.g. manual workflow_dispatch), where github.event.pull_request is empty
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
@@ -35,7 +42,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install -g @lhci/cli@0.11.x
+      - run: npm install -g @lhci/cli@0.15.x
       # Collect Lighthouse results
       - run: lhci autorun
         env:

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -4,6 +4,7 @@
       "numberOfRuns": 1,
       "staticDistDir": "./public",
       "maxAutodiscoverUrls": 0,
+      "staticDirFileDiscoveryDepth": 4,
       "autodiscoverUrlBlocklist": [
         "http://localhost/categories/index.html",
         "http://localhost/tags/index.html",
@@ -18,24 +19,11 @@
       }
     },
     "assert": {
-      "preset": "lighthouse:no-pwa",
       "assertions": {
         "categories:performance": ["warn", { "minScore": 0.9 }],
         "categories:accessibility": ["error", { "minScore": 1 }],
-        "csp-xss": "warn",
-        "is-crawlable": "warn",
-        "meta-description": "warn",
-        "unminified-css": "warn",
-        "unused-css-rules": "warn",
-        "uses-text-compression": "warn",
-        "unused-javascript": "warn",
-        "unminified-javascript": "warn",
-        "unsized-images": "warn",
-        "errors-in-console": "warn",
-        "crawlable-anchors": "warn",
-        "inspector-issues": "warn",
-        "uses-optimized-images": "warn",
-        "uses-responsive-images": "warn"
+        "categories:best-practices": ["warn"],
+        "categories:seo": ["warn"]
       }
     },
     "upload": {

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -2,32 +2,16 @@
   "ci": {
     "collect": {
       "numberOfRuns": 1,
-      "startServerCommand": "hugo server --environment production",
-      "url": [
-        "http://localhost:1313/",
-        "http://localhost:1313/accessibility-statement.html",
-        "http://localhost:1313/contact.html",
-        "http://localhost:1313/components/",
-        "http://localhost:1313/components/landmark/",
-        "http://localhost:1313/components/checkable/",
-        "http://localhost:1313/components/button-and-link/",
-        "http://localhost:1313/components/digital-info/",
-        "http://localhost:1313/components/form/",
-        "http://localhost:1313/components/official-document/",
-        "http://localhost:1313/components/skip-to/",
-        "http://localhost:1313/components/table/",
-        "http://localhost:1313/components/textarea/",
-        "http://localhost:1313/components/warning-text/",
-        "http://localhost:1313/components/accordion/",
-        "http://localhost:1313/components/tabs/",
-        "http://localhost:1313/technology/",
-        "http://localhost:1313/technology/anti_patterns/",
-        "http://localhost:1313/technology/internationalization/",
-        "http://localhost:1313/technology/progressive_enhancement/",
-        "http://localhost:1313/visual/",
-        "http://localhost:1313/visual/colors/",
-        "http://localhost:1313/visual/internationalization/",
-        "http://localhost:1313/visual/typography/"
+      "staticDistDir": "./public",
+      "maxAutodiscoverUrls": 0,
+      "autodiscoverUrlBlocklist": [
+        "http://localhost/categories/index.html",
+        "http://localhost/tags/index.html",
+        "http://localhost/components/landmark/blank.html",
+        "http://localhost/components/landmark/one-column.html",
+        "http://localhost/components/skip-to/skip-to.html",
+        "http://localhost/components/skip-to/skip-to-multiple.html",
+        "http://localhost/components/digital-info/digital-info.html"
       ],
       "settings": {
         "preset": "desktop"
@@ -43,7 +27,15 @@
         "meta-description": "warn",
         "unminified-css": "warn",
         "unused-css-rules": "warn",
-        "uses-text-compression": "warn"
+        "uses-text-compression": "warn",
+        "unused-javascript": "warn",
+        "unminified-javascript": "warn",
+        "unsized-images": "warn",
+        "errors-in-console": "warn",
+        "crawlable-anchors": "warn",
+        "inspector-issues": "warn",
+        "uses-optimized-images": "warn",
+        "uses-responsive-images": "warn"
       }
     },
     "upload": {

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -5,8 +5,8 @@
       "startServerCommand": "hugo server --environment production",
       "url": [
         "http://localhost:1313/",
-        "http://localhost:1313/accessibility-statement/",
-        "http://localhost:1313/contact/",
+        "http://localhost:1313/accessibility-statement.html",
+        "http://localhost:1313/contact.html",
         "http://localhost:1313/components/",
         "http://localhost:1313/components/landmark/",
         "http://localhost:1313/components/checkable/",

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -28,7 +28,7 @@
   <div class="ph2 tc w-100" style="flex: 1 1 calc(33.333% - 2rem)">
     <a class="db" {{ with $doc }}href="{{ .RelPermalink }}" {{ end }}>
       <div class="w-70 center">
-        <img src="{{ $svgPath | relURL }}" alt="{{ .Title }}" />
+        <img src="{{ $svgPath | relURL }}" alt="" />
       </div>
       <div class="mt3">{{ .Title }}</div>
     </a>


### PR DESCRIPTION
### 摘要

本 PR 針對 CI/CD workflows 進行安全性掃描後的修補,解決一個 **High** 等級漏洞與數個中低風險問題。

### 🔴 High:`pull_request_target` + 可變 ref 的 TOCTOU 攻擊(pwn request)

`build.yml` 使用 `pull_request_target` 觸發(帶有完整 secrets 存取權),但 checkout 的是 `head.ref`(**可變的分支名稱**)。攻擊情境:

1. 攻擊者從 fork 開 PR,內容看起來無害
2. 維護者審核後貼上 `safe-to-deploy` label
3. 攻擊者搶在 workflow checkout 之前 push 惡意 commit
4. 惡意程式碼在可存取 secrets(GCP Workload Identity、`GH_PAT`)的環境中執行

**修正**:checkout 改用事件觸發當下不可變的 `head.sha`,並加上 `persist-credentials: false` 避免 token 殘留於 git config。

### 🟠 Medium

- **`secrets: inherit` 過度授權**(`build.yml`):原本將所有 repo secrets 傳給 deploy job,改為只明確傳遞 `GC_WORKLOAD_IDENTITY_PROVIDER`
- **不必要的 `GH_PAT`**(`deploy.yml`):此 workflow 只透過同一 run 的 `workflow_call` 呼叫,下載 artifact 使用預設 job token 即可,移除 PAT 減少外洩風險
- **不必要的 checkout**(`deploy.yml`):deploy job 完全沒用到 repo 檔案,卻 checkout 了不受信任的 PR code,已移除

### 🟡 Low

- `build.yml` / `lhci.yml`:加上 top-level `permissions: contents: read`(最小權限)
- `deploy-to-gh-pages.yml`:移除永遠為空的 `pull_request` event 引用(此 workflow 僅由 `workflow_dispatch` 觸發)

### 變更檔案

| 檔案 | 變更 |
|---|---|
| `.github/workflows/build.yml` | checkout 改用 `head.sha`、`persist-credentials: false`、top-level permissions、明確傳遞 secrets |
| `.github/workflows/deploy.yml` | 移除 `GH_PAT` 與未使用的 checkout、宣告 `secrets` 介面 |
| `.github/workflows/deploy-to-gh-pages.yml` | 移除死碼(空的 pull_request event 引用) |
| `.github/workflows/lhci.yml` | 加上 top-level permissions |

### 後續建議(本 PR 未包含)

- [ ] 將所有 actions 從 tag(`@v4`)pin 到 full commit SHA,並以 Dependabot 管理更新
- [ ] 固定 `hugo-version` 取代 `"latest"`,確保供應鏈安全與 build 可重現性
- [ ] 確認團隊 `safe-to-deploy` label 流程:審核最新 commit 後才貼 label,新 commit 進來時移除舊 label
- [ ] 若 `GH_PAT` 已無其他用途,從 repo secrets 中刪除

### 測試方式

- 4 個 workflow 檔案皆通過 YAML / actions schema 驗證
- 建議合併前先以 `workflow_dispatch` 手動觸發 `build.yml` 驗證 build → deploy → comment 全流程