### PR TITLE
## ci: 強化 GitHub Actions workflows 安全性(修補 pwn-request 與 secrets 外洩風險)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 
+# Least-privilege default for all jobs; jobs elevate only what they need
+permissions:
+  contents: read
+
 jobs:
   build:
     # Run this job if the pull request is from the same repository or labeled with 'safe-to-deploy'
@@ -17,8 +21,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          # SECURITY: pin to the immutable commit SHA that was present when the
+          # event fired (e.g. when the 'safe-to-deploy' label was applied).
+          # Using head.ref (a mutable branch name) allows an attacker to push
+          # malicious commits after review/labeling (TOCTOU) that would then run
+          # under pull_request_target with access to secrets.
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # Don't leave the GITHUB_TOKEN in the git config while building
+          # untrusted PR content
+          persist-credentials: false
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
@@ -44,7 +56,10 @@ jobs:
       id-token: "write"
     with:
       RUN_ID: ${{ github.run_id }}
-    secrets: inherit
+    # SECURITY: pass only the secrets the reusable workflow needs instead of
+    # 'secrets: inherit', which would expose every repository secret
+    secrets:
+      GC_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}
   comment: # Required by peter-evans/create-or-update-comment@v4
     needs: deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # ref: https://github.com/actions/starter-workflows/tree/main/pages
+      # This workflow only runs on workflow_dispatch, so check out the
+      # triggering ref of this repository (the previous pull_request event
+      # fields were always empty here)
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Setup Hugo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
         default: "<RUN_ID>"
+    secrets:
+      GC_WORKLOAD_IDENTITY_PROVIDER:
+        required: true
 
 jobs:
   deploy-to-gcs:
@@ -16,18 +19,17 @@ jobs:
       id-token: "write"
 
     steps:
-      - name: Checkout
-        uses: "actions/checkout@v4"
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      # ref: https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories
+      # SECURITY: no checkout here — this job only downloads a build artifact
+      # and uploads it to GCS. Checking out untrusted PR code added attack
+      # surface for no benefit.
+      #
+      # SECURITY: this workflow is only invoked via workflow_call from the same
+      # run, so the artifact can be downloaded with the default job token —
+      # no personal access token (GH_PAT) is needed.
       - name: Download artifacts from build
         uses: actions/download-artifact@v4
         with:
           name: hugo-site
-          github-token: ${{ secrets.GH_PAT }} # personal access token with actions:read permissions on target repo
-          run-id: ${{ inputs.RUN_ID }}
           path: ./${{ inputs.RUN_ID }}
 
       - name: Authenticate to Google Cloud

--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -20,6 +20,9 @@ concurrency:
   group: lighthouse-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lighthouseci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### 摘要

本 PR 針對 CI/CD workflows 進行安全性掃描後的修補,解決一個 **High** 等級漏洞與數個中低風險問題。

### 🔴 High:`pull_request_target` + 可變 ref 的 TOCTOU 攻擊(pwn request)

`build.yml` 使用 `pull_request_target` 觸發(帶有完整 secrets 存取權),但 checkout 的是 `head.ref`(**可變的分支名稱**)。攻擊情境:

1. 攻擊者從 fork 開 PR,內容看起來無害
2. 維護者審核後貼上 `safe-to-deploy` label
3. 攻擊者搶在 workflow checkout 之前 push 惡意 commit
4. 惡意程式碼在可存取 secrets(GCP Workload Identity、`GH_PAT`)的環境中執行

**修正**:checkout 改用事件觸發當下不可變的 `head.sha`,並加上 `persist-credentials: false` 避免 token 殘留於 git config。

### 🟠 Medium

- **`secrets: inherit` 過度授權**(`build.yml`):原本將所有 repo secrets 傳給 deploy job,改為只明確傳遞 `GC_WORKLOAD_IDENTITY_PROVIDER`
- **不必要的 `GH_PAT`**(`deploy.yml`):此 workflow 只透過同一 run 的 `workflow_call` 呼叫,下載 artifact 使用預設 job token 即可,移除 PAT 減少外洩風險
- **不必要的 checkout**(`deploy.yml`):deploy job 完全沒用到 repo 檔案,卻 checkout 了不受信任的 PR code,已移除

### 🟡 Low

- `build.yml` / `lhci.yml`:加上 top-level `permissions: contents: read`(最小權限)
- `deploy-to-gh-pages.yml`:移除永遠為空的 `pull_request` event 引用(此 workflow 僅由 `workflow_dispatch` 觸發)

### 變更檔案

| 檔案 | 變更 |
|---|---|
| `.github/workflows/build.yml` | checkout 改用 `head.sha`、`persist-credentials: false`、top-level permissions、明確傳遞 secrets |
| `.github/workflows/deploy.yml` | 移除 `GH_PAT` 與未使用的 checkout、宣告 `secrets` 介面 |
| `.github/workflows/deploy-to-gh-pages.yml` | 移除死碼(空的 pull_request event 引用) |
| `.github/workflows/lhci.yml` | 加上 top-level permissions |

### 後續建議(本 PR 未包含)

- [ ] 將所有 actions 從 tag(`@v4`)pin 到 full commit SHA,並以 Dependabot 管理更新
- [ ] 固定 `hugo-version` 取代 `"latest"`,確保供應鏈安全與 build 可重現性
- [ ] 確認團隊 `safe-to-deploy` label 流程:審核最新 commit 後才貼 label,新 commit 進來時移除舊 label
- [ ] 若 `GH_PAT` 已無其他用途,從 repo secrets 中刪除

### 測試方式

- 4 個 workflow 檔案皆通過 YAML / actions schema 驗證
- 建議合併前先以 `workflow_dispatch` 手動觸發 `build.yml` 驗證 build → deploy → comment 全流程